### PR TITLE
Initial format lambda and container build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,8 @@
+FROM public.ecr.aws/lambda/python:3.9
+
+# Copy function code
+COPY format.py ${LAMBDA_TASK_ROOT}
+COPY ping.py ${LAMBDA_TASK_ROOT}
+
+# Default handler. See README for how to override to a different handler.
+CMD [ "format.lambda_handler" ]

--- a/README.md
+++ b/README.md
@@ -1,0 +1,132 @@
+# TIMDEX Pipeline Lambdas
+
+TIMDEX Pipeline Lambdas is a collection of lambdas used in the TIMDEX Ingest Pipeline.
+
+## Format Handler
+
+Takes an input from EventBridge and formats the event data to work throughout the entire ingest pipeline.
+
+### Example Format input
+
+```json
+{
+  "harvest-type": "update",
+  "time": "2022-03-10T16:30:23Z",
+  "oai-pmh-host": "https://YOUR-OAI-SOURCE/oai",
+  "oai-metadata-format": "oai_ead",
+  "source": "aspace",
+  "output-bucket": "YOURBUCKET",
+  "elasticsearch-url": "https://YOUR-ES-URL"
+}
+```
+
+### Example Format output
+
+```json
+{
+  "harvest": {
+    "commands": [
+      "--host=https://YOUR-OAI-SOURCE/oai",
+      "--out=s3://YOURBUCKET/aspace-daily-harvest-oai_ead-2022-03-09.xml",
+      "harvest",
+      "--from_date=2022-03-09",
+      "--until=2022-03-09",
+      "--format=oai_ead"
+    ],
+    "result-file": {
+      "bucket": "YOURBUCKET",
+      "key": "aspace-daily-harvest-oai_ead-2022-03-09.xml"
+    }
+  },
+  "ingest": {
+    "commands": [
+      "--url=https://YOUR-ES-URL",
+      "ingest",
+      "--source=aspace",
+      "s3://YOURBUCKET/aspace-daily-harvest-oai_ead-2022-03-09.xml"
+    ]
+  }
+}
+```
+
+## Ping Handler
+
+Useful for testing and little else.
+
+### Example Ping input
+
+`{}`
+
+### Example Ping output
+
+`pong`
+
+## Developing locally
+
+<https://docs.aws.amazon.com/lambda/latest/dg/images-test.html>
+
+### Build the container
+
+```bash
+docker build -t timdex-pipeline-lambdas .
+```
+
+### Run the default handler for the container
+
+```bash
+docker run -p 9000:8080 timdex-pipeline-lambdas:latest
+```
+
+### POST to the container
+
+```bash
+curl -XPOST "http://localhost:9000/2015-03-31/functions/function/invocations" -d '{
+                                      "harvest-type": "update",
+                                      "time": "2022-03-10T16:30:23Z",
+                                      "oai-pmh-host": "https://YOUR-OAI-SOURCE/oai",
+                                      "oai-metadata-format": "oai_ead",
+                                      "source": "aspace",
+                                      "output-bucket": "YOURBUCKET",
+                                      "elasticsearch-url": "https://YOUR-ES-URL"
+                                    }'
+```
+
+### Observe output
+
+```json
+{
+  "harvest": {
+    "commands": [
+      "--host=https://YOUR-OAI-SOURCE/oai",
+      "--out=s3://YOURBUCKET/aspace-daily-harvest-oai_ead-2022-03-09.xml",
+      "harvest",
+      "--from_date=2022-03-09",
+      "--until=2022-03-09",
+      "--format=oai_ead"
+    ],
+    "result-file": {
+      "bucket": "YOURBUCKET",
+      "key": "aspace-daily-harvest-oai_ead-2022-03-09.xml"
+    }
+  },
+  "ingest": {
+    "commands": [
+      "--url=https://YOUR-ES-URL",
+      "ingest",
+      "--source=aspace",
+      "s3://YOURBUCKET/aspace-daily-harvest-oai_ead-2022-03-09.xml"
+    ]
+  }
+}
+```
+
+### Run a different handler in the container
+
+You can call any handler you copy into the container (see Dockerfile) by name as part of the `docker run` command.
+
+```bash
+docker run -p 9000:8080 timdex-pipeline-lambdas:latest ping.lambda_handler
+curl -XPOST "http://localhost:9000/2015-03-31/functions/function/invocations" -d '{}'
+```
+
+Should result in `pong` as the output.

--- a/format.py
+++ b/format.py
@@ -1,0 +1,73 @@
+import datetime
+
+
+def lambda_handler(event, context):
+
+    run_date = datetime.datetime.strptime(event["time"], "%Y-%m-%dT%H:%M:%SZ")
+    harvest_date = run_date - datetime.timedelta(days=1)
+    formatted_harvest_date = harvest_date.strftime("%Y-%m-%d")
+
+    harvest_type = event["harvest-type"]
+
+    if harvest_type == "update":
+        output_file = (
+            f"{event['source']}-daily-harvest-{event['oai-metadata-format']}"
+            f"-{formatted_harvest_date}.xml"
+        )
+        output = {
+            "harvest": {
+                "commands": [
+                    f"--host={event['oai-pmh-host']}",
+                    f"--out=s3://{event['output-bucket']}/{output_file}",
+                    "harvest",
+                    f"--from_date={formatted_harvest_date}",
+                    f"--until={formatted_harvest_date}",
+                    f"--format={event['oai-metadata-format']}"
+                ],
+                "result-file": {
+                    "bucket": event['output-bucket'],
+                    "key": output_file
+                }
+            },
+            "ingest": {
+                "commands": [
+                    f"--url={event['elasticsearch-url']}",
+                    "ingest",
+                    f"--source={event['source']}",
+                    f"s3://{event['output-bucket']}/{output_file}"
+                ]
+            }
+        }
+
+    elif harvest_type == "full":
+        output_file = (
+            f"{event['source']}-full-harvest-{event['oai-metadata-format']}"
+            f"-{formatted_harvest_date}.xml"
+        )
+        output = {
+            "harvest": {
+                "commands": [
+                    f"--host={event['oai-pmh-host']}",
+                    f"--out=s3://{event['output-bucket']}/{output_file}",
+                    "harvest",
+                    f"--until={formatted_harvest_date}",
+                    f"--format={event['oai-metadata-format']}"
+                ],
+                "result-file": {
+                    "bucket": event['output-bucket'],
+                    "key": output_file
+                }
+            },
+            "ingest": {
+                "commands": [
+                    f"--url={event['elasticsearch-url']}",
+                    "ingest",
+                    f"--source={event['source']}",
+                    "--new",
+                    "--auto",
+                    f"s3://{event['output-bucket']}/{output_file}"
+                ]
+            }
+        }
+
+    return output

--- a/ping.py
+++ b/ping.py
@@ -1,0 +1,2 @@
+def lambda_handler(event, context):
+    return "pong"

--- a/test_format.py
+++ b/test_format.py
@@ -1,0 +1,39 @@
+import format
+
+
+def test_format():
+    input = {
+        "harvest-type": "update",
+        "time": "2022-03-10T16:30:23Z",
+        "oai-pmh-host": "https://YOUR-OAI-SOURCE/oai",
+        "oai-metadata-format": "oai_ead",
+        "source": "aspace",
+        "output-bucket": "YOURBUCKET",
+        "elasticsearch-url": "https://YOUR-ES-URL"
+    }
+
+    expected_output = {
+        "harvest": {
+            "commands": [
+                "--host=https://YOUR-OAI-SOURCE/oai",
+                "--out=s3://YOURBUCKET/aspace-daily-harvest-oai_ead-2022-03-09.xml",
+                "harvest",
+                "--from_date=2022-03-09",
+                "--until=2022-03-09",
+                "--format=oai_ead"
+            ],
+            "result-file": {
+                "bucket": "YOURBUCKET",
+                "key": "aspace-daily-harvest-oai_ead-2022-03-09.xml"
+            }
+        },
+        "ingest": {
+            "commands": [
+                "--url=https://YOUR-ES-URL",
+                "ingest",
+                "--source=aspace",
+                "s3://YOURBUCKET/aspace-daily-harvest-oai_ead-2022-03-09.xml"
+            ]
+        }
+    }
+    assert expected_output == format.lambda_handler(input, {})

--- a/test_ping.py
+++ b/test_ping.py
@@ -1,0 +1,9 @@
+import ping
+
+
+def test_ping():
+    assert ping.lambda_handler({}, {}) == "pong"
+
+
+def test_ping_always_pongs():
+    assert ping.lambda_handler({'hallo': 'cheese'}, {}) == "pong"


### PR DESCRIPTION
Why are these changes being introduced:

* We need to be able to run lambdas as part of the timdex ingest process

Relevant ticket(s):

* https://mitlibraries.atlassian.net/browse/RDI-48

How does this address that need:

* creates a Dockerfile that imports lambdas
* provides documentation on how to work with the lambdas locally
* includes some initital tests

Document any side effects to this change:

This should allow for multiple lambdas to be built for the timdex
pipline in this single repository and single container but be callable
separately as needed within the pipeline. Each lambda would need to
still be setup, but only one ECR should be required for all of them
in this pipeline.