### PR TITLE
create a makefile for use with aws

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,22 @@
+SHELL=/bin/bash
+DATETIME:=$(shell date -u +%Y%m%dT%H%M%SZ)
+ECR_REGISTRY_DEV=$(shell aws sts get-caller-identity --query Account --output text).dkr.ecr.us-east-1.amazonaws.com
+
+help: ## Print this message
+	@awk 'BEGIN { FS = ":.*##"; print "Usage:  make <target>\n\nTargets:" } \
+/^[-_[:alpha:]]+:.?*##/ { printf "  %-15s%s\n", $$1, $$2 }' $(MAKEFILE_LIST)
+
+dist-dev: ## Build docker container
+	docker build --platform linux/amd64 -t $(ECR_REGISTRY_DEV)/timdex-input-format-dev:latest \
+		-t $(ECR_REGISTRY_DEV)/timdex-input-format-dev:`git describe --always` .	
+
+publish-dev: dist ## Build, tag and push
+	docker login -u AWS -p $$(aws ecr get-login-password --region us-east-1) $(ECR_REGISTRY_DEV)
+	docker push $(ECR_REGISTRY_DEV)/timdex-input-format-dev:latest
+	docker push $(ECR_REGISTRY_DEV)/timdex-input-format-dev:`git describe --always`
+
+update-format-lambda-dev: ## Updates the lambda with whatever is the most recent image in the ecr
+	aws lambda update-function-code \
+		--function-name timdex-format-dev \
+		--image-uri $(shell aws sts get-caller-identity --query Account --output text).dkr.ecr.us-east-1.amazonaws.com/timdex-input-format-dev:latest
+

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ dist-dev: ## Build docker container
 	docker build --platform linux/amd64 -t $(ECR_REGISTRY_DEV)/timdex-input-format-dev:latest \
 		-t $(ECR_REGISTRY_DEV)/timdex-input-format-dev:`git describe --always` .	
 
-publish-dev: dist ## Build, tag and push
+publish-dev: dist-dev ## Build, tag and push
 	docker login -u AWS -p $$(aws ecr get-login-password --region us-east-1) $(ECR_REGISTRY_DEV)
 	docker push $(ECR_REGISTRY_DEV)/timdex-input-format-dev:latest
 	docker push $(ECR_REGISTRY_DEV)/timdex-input-format-dev:`git describe --always`

--- a/README.md
+++ b/README.md
@@ -130,3 +130,11 @@ curl -XPOST "http://localhost:9000/2015-03-31/functions/function/invocations" -d
 ```
 
 Should result in `pong` as the output.
+
+
+### Makefile Use for AWS
+
+A makefile is provided with account specific "dist" "publish" and "update-format-lambda"
+
+"Update-format-lambda" is required anytime an image is published to the ECR in order for the lambda to use the updated code.  
+


### PR DESCRIPTION
This makefile allows for easy compilation and publishing of the lambda function container to aws.  
It also allows easy updating of the lambda function with the most recent image available.

Its important to use the correct (dev) context when using the makefile.  The final version of this file will primarily be used by github actions to complete publishes and update automatically, but we may choose to promote to prod by hand(tbd).  

For now, this is for ease of use as we continue to do testing in dev.  