### PR TITLE
Update format lambda to match oai-pmh-harvester changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Takes an input from EventBridge and formats the event data to work throughout th
   "time": "2022-03-10T16:30:23Z",
   "oai-pmh-host": "https://YOUR-OAI-SOURCE/oai",
   "oai-metadata-format": "oai_ead",
+  "oai-set-spec": "collection_1", # Note this input field is optional
   "source": "aspace",
   "output-bucket": "YOURBUCKET",
   "elasticsearch-url": "https://YOUR-ES-URL"
@@ -27,11 +28,13 @@ Takes an input from EventBridge and formats the event data to work throughout th
   "harvest": {
     "commands": [
       "--host=https://YOUR-OAI-SOURCE/oai",
-      "--out=s3://YOURBUCKET/aspace-daily-harvest-oai_ead-2022-03-09.xml",
+      "--output-file=s3://YOURBUCKET/aspace-daily-harvest-oai_ead-2022-03-09.xml",
       "harvest",
-      "--from_date=2022-03-09",
-      "--until=2022-03-09",
-      "--format=oai_ead"
+      "--metadata-format=oai_ead",
+      "--from-date=2022-03-09",
+      "--until-date=2022-03-09",
+      "--exclude-deleted", # Note we currently always exclude deleted records
+      "--set-spec=collection_1"
     ],
     "result-file": {
       "bucket": "YOURBUCKET",
@@ -85,6 +88,7 @@ curl -XPOST "http://localhost:9000/2015-03-31/functions/function/invocations" -d
                                       "time": "2022-03-10T16:30:23Z",
                                       "oai-pmh-host": "https://YOUR-OAI-SOURCE/oai",
                                       "oai-metadata-format": "oai_ead",
+                                      "oai-set-spec": "collection_1",
                                       "source": "aspace",
                                       "output-bucket": "YOURBUCKET",
                                       "elasticsearch-url": "https://YOUR-ES-URL"
@@ -98,11 +102,13 @@ curl -XPOST "http://localhost:9000/2015-03-31/functions/function/invocations" -d
   "harvest": {
     "commands": [
       "--host=https://YOUR-OAI-SOURCE/oai",
-      "--out=s3://YOURBUCKET/aspace-daily-harvest-oai_ead-2022-03-09.xml",
+      "--output-file=s3://YOURBUCKET/aspace-daily-harvest-oai_ead-2022-03-09.xml",
       "harvest",
-      "--from_date=2022-03-09",
-      "--until=2022-03-09",
-      "--format=oai_ead"
+      "--metadata-format=oai_ead",
+      "--from-date=2022-03-09",
+      "--until-date=2022-03-09",
+      "--exclude-deleted",
+      "--set-spec=collection_1"
     ],
     "result-file": {
       "bucket": "YOURBUCKET",
@@ -134,7 +140,7 @@ Should result in `pong` as the output.
 
 ### Makefile Use for AWS
 
-A makefile is provided with account specific "dist" "publish" and "update-format-lambda"
+A makefile is provided with account specific "dist" "publish" and "update-format-lambda" commands.
 
 "Update-format-lambda" is required anytime an image is published to the ECR that contains a change to the format function in order for the format-lambda to use the updated code.  
 

--- a/format.py
+++ b/format.py
@@ -4,6 +4,8 @@ import datetime
 def lambda_handler(event, context):
 
     run_date = datetime.datetime.strptime(event["time"], "%Y-%m-%dT%H:%M:%SZ")
+    formatted_run_date = run_date.strftime("%Y-%m-%d")
+
     harvest_date = run_date - datetime.timedelta(days=1)
     formatted_harvest_date = harvest_date.strftime("%Y-%m-%d")
 
@@ -14,16 +16,21 @@ def lambda_handler(event, context):
             f"{event['source']}-daily-harvest-{event['oai-metadata-format']}"
             f"-{formatted_harvest_date}.xml"
         )
+        harvest_commands = [
+            f"--host={event['oai-pmh-host']}",
+            f"--output-file=s3://{event['output-bucket']}/{output_file}",
+            "harvest",
+            f"--metadata-format={event['oai-metadata-format']}",
+            f"--from-date={formatted_harvest_date}",
+            f"--until-date={formatted_harvest_date}",
+            "--exclude-deleted",
+        ]
+        if event.get("oai-set-spec"):
+            harvest_commands.append(f"--set-spec={event['oai-set-spec']}")
+
         output = {
             "harvest": {
-                "commands": [
-                    f"--host={event['oai-pmh-host']}",
-                    f"--out=s3://{event['output-bucket']}/{output_file}",
-                    "harvest",
-                    f"--from_date={formatted_harvest_date}",
-                    f"--until={formatted_harvest_date}",
-                    f"--format={event['oai-metadata-format']}"
-                ],
+                "commands": harvest_commands,
                 "result-file": {
                     "bucket": event['output-bucket'],
                     "key": output_file
@@ -42,17 +49,21 @@ def lambda_handler(event, context):
     elif harvest_type == "full":
         output_file = (
             f"{event['source']}-full-harvest-{event['oai-metadata-format']}"
-            f"-{formatted_harvest_date}.xml"
+            f"-{formatted_run_date}.xml"
         )
+        harvest_commands = [
+            f"--host={event['oai-pmh-host']}",
+            f"--output-file=s3://{event['output-bucket']}/{output_file}",
+            "harvest",
+            f"--metadata-format={event['oai-metadata-format']}",
+            "--exclude-deleted",
+        ]
+        if event.get("oai-set-spec"):
+            harvest_commands.append(f"--set-spec={event['oai-set-spec']}")
+
         output = {
             "harvest": {
-                "commands": [
-                    f"--host={event['oai-pmh-host']}",
-                    f"--out=s3://{event['output-bucket']}/{output_file}",
-                    "harvest",
-                    f"--until={formatted_harvest_date}",
-                    f"--format={event['oai-metadata-format']}"
-                ],
+                "commands": harvest_commands,
                 "result-file": {
                     "bucket": event['output-bucket'],
                     "key": output_file

--- a/test_format.py
+++ b/test_format.py
@@ -1,12 +1,13 @@
-import format
+import format_input
 
 
-def test_format():
-    input = {
+def test_format_input_daily_update():
+    test_input = {
         "harvest-type": "update",
         "time": "2022-03-10T16:30:23Z",
         "oai-pmh-host": "https://YOUR-OAI-SOURCE/oai",
         "oai-metadata-format": "oai_ead",
+        "oai-set-spec": "collection_1",
         "source": "aspace",
         "output-bucket": "YOURBUCKET",
         "elasticsearch-url": "https://YOUR-ES-URL"
@@ -16,11 +17,14 @@ def test_format():
         "harvest": {
             "commands": [
                 "--host=https://YOUR-OAI-SOURCE/oai",
-                "--out=s3://YOURBUCKET/aspace-daily-harvest-oai_ead-2022-03-09.xml",
+                "--output-file=s3://YOURBUCKET/aspace-daily-harvest-oai_ead-"
+                "2022-03-09.xml",
                 "harvest",
-                "--from_date=2022-03-09",
-                "--until=2022-03-09",
-                "--format=oai_ead"
+                "--metadata-format=oai_ead",
+                "--from-date=2022-03-09",
+                "--until-date=2022-03-09",
+                "--exclude-deleted",
+                "--set-spec=collection_1"
             ],
             "result-file": {
                 "bucket": "YOURBUCKET",
@@ -36,4 +40,44 @@ def test_format():
             ]
         }
     }
-    assert expected_output == format.lambda_handler(input, {})
+    assert expected_output == format_input.lambda_handler(test_input, {})
+
+
+def test_format_input_full():
+    test_input = {
+        "harvest-type": "full",
+        "time": "2022-03-10T16:30:23Z",
+        "oai-pmh-host": "https://YOUR-OAI-SOURCE/oai",
+        "oai-metadata-format": "oai_ead",
+        "source": "aspace",
+        "output-bucket": "YOURBUCKET",
+        "elasticsearch-url": "https://YOUR-ES-URL"
+    }
+
+    expected_output = {
+        "harvest": {
+            "commands": [
+                "--host=https://YOUR-OAI-SOURCE/oai",
+                "--output-file=s3://YOURBUCKET/aspace-full-harvest-oai_ead-"
+                "2022-03-10.xml",
+                "harvest",
+                "--metadata-format=oai_ead",
+                "--exclude-deleted"
+            ],
+            "result-file": {
+                "bucket": "YOURBUCKET",
+                "key": "aspace-full-harvest-oai_ead-2022-03-10.xml"
+            }
+        },
+        "ingest": {
+            "commands": [
+                "--url=https://YOUR-ES-URL",
+                "ingest",
+                "--source=aspace",
+                "--new",
+                "--auto",
+                "s3://YOURBUCKET/aspace-full-harvest-oai_ead-2022-03-10.xml"
+            ]
+        }
+    }
+    assert expected_output == format_input.lambda_handler(test_input, {})


### PR DESCRIPTION
#### Why these changes are being introduced:
The oai-pmh-harvester's CLI command options were recently updated, so the input format lambda also needs to be updated to match the new options.

#### How this addresses that need:
* Updates format.py to output the new harvest commands/options as required by oai-pmh-harvester
* Updates test_format.py to reflect expected output
* Updates README to reflect expected input and output

#### Additional changes:
Removes the "--until-date" option on full harvests, since those should harvest up to and including the current date. Consequently changes the name of the full harvest output file to use the run date instead of the day before the run (as is used for daily updates).

#### Side effects of this change:
None, this doesn't change the expected input (except for adding a new optional set-spec field, which if not included will simply be ignored so this won't impact any existing Eventbridge rules).

Relevant ticket(s):
* https://mitlibraries.atlassian.net/browse/RDI-79