### PR TITLE
Lambda Deploy Automation

### DIFF
--- a/.github/workflows/dev-build.yml
+++ b/.github/workflows/dev-build.yml
@@ -1,0 +1,20 @@
+### This is the Terraform-generated dev-build.yml workflow for the timdex-pipeline-lambdas app repository ###
+name: Dev Build and Deploy Lambda
+on:
+  workflow_dispatch:
+  pull_request:
+    branches:
+      - main
+    paths-ignore:
+      - '.github/**'
+
+jobs:
+  deploy:
+    name: Dev Deploy Lambda Container
+    uses: mitlibraries/.github/.github/workflows/lambda-shared-deploy-dev.yml@container-flows
+    secrets: inherit
+    with:
+      AWS_REGION: "us-east-1"
+      GHA_ROLE: "timdex-pipeline-lambdas-gha-dev"
+      ECR: "timdex-pipeline-lambdas-dev"
+      FUNCTION: "timdex-format-dev"

--- a/.github/workflows/dev_ecr_push.yml
+++ b/.github/workflows/dev_ecr_push.yml
@@ -35,5 +35,4 @@ jobs:
       - name: Push image
         run: make publish-dev
       - name: Update format-lambda
-        run: make update-format-lambda-dev
-
+        run: make update-lambda-dev

--- a/Makefile
+++ b/Makefile
@@ -1,22 +1,27 @@
+### This is the Terraform-generated header for the timdex-pipeline-lambads Makefile ###
 SHELL=/bin/bash
 DATETIME:=$(shell date -u +%Y%m%dT%H%M%SZ)
-ECR_REGISTRY_DEV=$(shell aws sts get-caller-identity --query Account --output text).dkr.ecr.us-east-1.amazonaws.com
+ECR:=222053980223.dkr.ecr.us-east-1.amazonaws.com
+ECR_NAME:=timdex-pipeline-lambdas-dev
+ECR_URL:=222053980223.dkr.ecr.us-east-1.amazonaws.com/timdex-pipeline-lambdas-dev
+FUNCTION:=timdex-format-dev
+### End of Terraform-generated header ###
+
 
 help: ## Print this message
 	@awk 'BEGIN { FS = ":.*##"; print "Usage:  make <target>\n\nTargets:" } \
 /^[-_[:alpha:]]+:.?*##/ { printf "  %-15s%s\n", $$1, $$2 }' $(MAKEFILE_LIST)
 
 dist-dev: ## Build docker container
-	docker build --platform linux/amd64 -t $(ECR_REGISTRY_DEV)/timdex-pipeline-lambdas-dev:latest \
-		-t $(ECR_REGISTRY_DEV)/timdex-pipeline-lambdas-dev:`git describe --always` .	
+	docker build --platform linux/amd64 \
+	    -t $(ECR_URL):latest \
+		-t $(ECR_URL):`git describe --always` \
+		-t $(ECR_NAME):latest .
 
 publish-dev: dist-dev ## Build, tag and push
-	docker login -u AWS -p $$(aws ecr get-login-password --region us-east-1) $(ECR_REGISTRY_DEV)
-	docker push $(ECR_REGISTRY_DEV)/timdex-pipeline-lambdas-dev:latest
-	docker push $(ECR_REGISTRY_DEV)/timdex-pipeline-lambdas-dev:`git describe --always`
+	docker login -u AWS -p $$(aws ecr get-login-password --region us-east-1) $(ECR_URL)
+	docker push $(ECR_URL):latest
+	docker push $(ECR_URL):`git describe --always`
 
 update-format-lambda-dev: ## Updates the lambda with whatever is the most recent image in the ecr
-	aws lambda update-function-code \
-		--function-name timdex-format-dev \
-		--image-uri $(shell aws sts get-caller-identity --query Account --output text).dkr.ecr.us-east-1.amazonaws.com/timdex-pipeline-lambdas-dev:latest
-
+	aws lambda update-function-code --function-name $(FUNCTION) --image-uri $(ECR_URL):latest

--- a/Makefile
+++ b/Makefile
@@ -23,5 +23,5 @@ publish-dev: dist-dev ## Build, tag and push
 	docker push $(ECR_URL):latest
 	docker push $(ECR_URL):`git describe --always`
 
-update-format-lambda-dev: ## Updates the lambda with whatever is the most recent image in the ecr
+update-lambda-dev: ## Updates the lambda with whatever is the most recent image in the ecr
 	aws lambda update-function-code --function-name $(FUNCTION) --image-uri $(ECR_URL):latest

--- a/README.md
+++ b/README.md
@@ -165,7 +165,6 @@ curl -XPOST "http://localhost:9000/2015-03-31/functions/function/invocations" -d
 
 Should result in `pong` as the output.
 
-
 ## Makefile Use for AWS
 
 A makefile is provided with account specific "dist" "publish" and "update-format-lambda" commands.


### PR DESCRIPTION
There are just two changes: an updated `Makefile` and a new `dev-build.yml` GitHub Action workflow.

## Overview of auto-deploy process

This is a simple local caller workflow that uses a shared workflow in our [.github](https://github.com/MITLibraries/.github) repository. The shared workflows can be found in the [container-flows](https://github.com/MITLibraries/.github/tree/container-flows) branch.

1. The `dev-build.yml` workflow calls the[ lambda-shared-deploy-dev.yml](https://github.com/MITLibraries/.github/blob/container-flows/.github/workflows/lambda-shared-deploy-dev.yml) workflow and passes to it the AWS region, the OIDC GitHub Action role, the name of the ECR repository, and the name of the Lambda function. 
2. The `lambda-shared-deploy-dev.yml` workflow handles the OIDC auth to AWS and then runs the sequence of `docker build` and `docker push` commands to update the container in the AWS ECR repository. The last step the shared workflow does is update the Lambda function itself to load the new container.

## Workflow update

There is a new workflow [dev-build.yml](.github/workflows/dev-build.yml) that is currently configured with two triggers: 
* `workflow_dispatch`: this is here so that a reviewer can test the functionality of the workflow by running it manually in the Actions tab on this repository
* `on.pull_request.branches: main`: When this PR is created, this workflow should (should have?) run and pushed a new version of the container to the ECR and updated the Lambda function to use the new version of the container.
This new workflow is generated by the Terraform code that builds the ECR and Lambda Function infrastructure (and is stored as a Terraform Output for easy copy/paste).

## Makefile update

The `Makefile` gets a new header with additional environment variables. Like the new workflow, this header text is generated by the Terraform infrastructure code and stored as a Terraform Output for easy copy/paste. The expanded header sets the appropriate values for the ECR repo name & URL, the Lambda Function name, and the ECR hostname. This allows for a simpler set of commands in the Makefile for the local developer to use that is tightly integrated with the Dev1 AWS Account and the correct names/locations for the lined infrastructure.

The code that generates the `Makefile` header and the `dev-build.yml` workflow can be found in [here](https://github.com/MITLibraries/mitlib-tf-sandbox-timdex-infrastructure/blob/dev/outputs.tf).

## How to Verify/Review

To verify that the automation worked, there are two places to look:
1. In the Actions tab of the repo, you should find the triggered run. You can/should dig into the details of that run to verify that all the steps worked and that there was nothing funny going on or any secret information revealed.
4. In the Dev1 AWS Account, you should go in to the AWS Console and review both the Lambda function itself (to see what version of the container it is running) and the ECR repository to see the updated container.

The link below should take you straight to the ECR Repository (`timdex-pipeline-lambdas-dev`) to see the list of the last five container versions (**NOTE: You need to log in to AWS SSO and then log in to the Dev1 account before this link will work**):
https://us-east-1.console.aws.amazon.com/ecr/repositories/private/222053980223/timdex-pipeline-lambdas-dev?region=us-east-1

The link below should take you straight to the Lambda function (`timdex-format-dev`) to see what version of the container is currently loaded (**NOTE: You need to log in to AWS SSO and then log in to the Dev1 account before this link will work**):
https://us-east-1.console.aws.amazon.com/lambda/home?region=us-east-1#/functions/timdex-format-dev?tab=code

You should also verify that you can still `docker push` and `lambda update` from your local computer by executing your typical `make dist-dev`, `make publish-dev`, and `make update-lambda-dev` commands (after logging in to AWS in your terminal session).

## Final comment 

This is just a first step -- there is no automation configured yet for a merge to `main` nor for a tagged release on `main`. This is because we have **not** built the necessary infrastructure in Stage-Workloads or Prod-Workloads to support this yet.