### PR TITLE
workflow and makfile updates

### DIFF
--- a/.github/workflows/dev-build.yml
+++ b/.github/workflows/dev-build.yml
@@ -1,5 +1,5 @@
-### This is the Terraform-generated dev-build.yml workflow for the timdex-pipeline-lambdas app repository ###
-name: Dev Build and Deploy Lambda
+### This is the Terraform-generated dev-build.yml workflow for the timdex-format-dev app repository ###
+name: Dev Build and Deploy lambda Container
 on:
   workflow_dispatch:
   pull_request:
@@ -10,8 +10,8 @@ on:
 
 jobs:
   deploy:
-    name: Dev Deploy Lambda Container
-    uses: mitlibraries/.github/.github/workflows/lambda-shared-deploy-dev.yml@container-flows
+    name: Dev Deploy lambda Container
+    uses: mitlibraries/.github/.github/workflows/lambda-shared-deploy-dev.yml@main
     secrets: inherit
     with:
       AWS_REGION: "us-east-1"

--- a/.github/workflows/prod-promote.yml
+++ b/.github/workflows/prod-promote.yml
@@ -1,0 +1,20 @@
+### This is the Terraform-generated prod-promote.yml workflow for the timdex-format-prod app repository ###
+name: Prod Promote Lambda Container
+on:
+  workflow_dispatch:
+  release:
+    types: [published]
+
+jobs:
+  deploy:
+    name: Prod Promote Lambda Container
+    uses: mitlibraries/.github/.github/workflows/lambda-shared-promote-prod.yml@main
+    secrets: inherit
+    with:
+      AWS_REGION: "us-east-1"
+      GHA_ROLE_STAGE: timdex-pipeline-lambdas-gha-stage
+      GHA_ROLE_PROD: timdex-pipeline-lambdas-gha-prod
+      ECR_STAGE: "timdex-pipeline-lambdas-stage"
+      ECR_PROD: "timdex-pipeline-lambdas-prod"
+      FUNCTION: "timdex-format-prod"
+ 

--- a/.github/workflows/stage-build.yml
+++ b/.github/workflows/stage-build.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   deploy:
     name: Stage Deploy Lambda Container
-    uses: mitlibraries/.github/.github/workflows/lambda-shared-deploy-stage.yml@container-flows
+    uses: mitlibraries/.github/.github/workflows/lambda-shared-deploy-stage.yml@main
     secrets: inherit
     with:
       AWS_REGION: "us-east-1"

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 ### This is the Terraform-generated header for the timdex-pipeline-lambads Makefile ###
 SHELL=/bin/bash
 DATETIME:=$(shell date -u +%Y%m%dT%H%M%SZ)
-### This is the Terraform-generated header for timdex-pipeline-lambdas-dev
+### This is the Terraform-generated header for timdex-pipeline-lambdas-dev ###
 ECR_NAME_DEV:=timdex-pipeline-lambdas-dev
 ECR_URL_DEV:=222053980223.dkr.ecr.us-east-1.amazonaws.com/timdex-pipeline-lambdas-dev
 FUNCTION_DEV:=timdex-format-dev
@@ -11,7 +11,7 @@ help: ## Print this message
 	@awk 'BEGIN { FS = ":.*##"; print "Usage:  make <target>\n\nTargets:" } \
 /^[-_[:alpha:]]+:.?*##/ { printf "  %-15s%s\n", $$1, $$2 }' $(MAKEFILE_LIST)
 
-### Developer Deploy Commands ###
+### Terraform-generated Developer Deploy Commands for Dev environment ###
 dist-dev: ## Build docker container (intended for developer-based manual build)
 	docker build --platform linux/amd64 \
 	    -t $(ECR_URL_DEV):latest \
@@ -24,7 +24,23 @@ publish-dev: dist-dev ## Build, tag and push (intended for developer-based manua
 	docker push $(ECR_URL_DEV):`git describe --always`
 
 update-lambda-dev: ## Updates the lambda with whatever is the most recent image in the ecr (intended for developer-based manual update)
-	aws lambda update-function-code \
-		--function-name $(FUNCTION_DEV) \
-		--image-uri $(ECR_URL_DEV):latest
-		
+	aws lambda update-function-code --function-name $(FUNCTION_DEV) --image-uri $(ECR_URL_DEV):latest
+
+
+### Terraform-generated manual shortcuts for deploying to Stage ###
+### This requires that ECR_NAME_STAGE, ECR_URL_STAGE, and FUNCTION_STAGE environment variables are 
+### set locally by the developer and that the developer has authenticated to the correct AWS Account.
+### The values for the environment variables can be found in the stage_build.yml caller workflow.
+dist-stage: ## Only use in an emergency
+	docker build --platform linux/amd64 \
+	    -t $(ECR_URL_STAGE):latest \
+		-t $(ECR_URL_STAGE):`git describe --always` \
+		-t $(ECR_NAME_STAGE):latest .
+
+publish-stage: ## Only use in an emergency
+	docker login -u AWS -p $$(aws ecr get-login-password --region us-east-1) $(ECR_URL_STAGE)
+	docker push $(ECR_URL_STAGE):latest
+	docker push $(ECR_URL_STAGE):`git describe --always`
+
+update-lambda-stage: ## Updates the lambda with whatever is the most recent image in the ecr (intended for developer-based manual update)
+	aws lambda update-function-code --function-name $(FUNCTION_STAGE) --image-uri $(ECR_URL_STAGE):latest


### PR DESCRIPTION
Now that we have landed on a final version of workflows and makefiles for our projects, I need to do 1 more revision of the Workflows and makefile.

This sets up/refines all workflows and the makefile

It adds the prod promote workflow, which will not work until we deploy prod

This is a copy/paste from the ECR infrastructure output, this output is available to the devs in terraform cloud.