### PR TITLE
Add Sentry integration

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -4,6 +4,7 @@ verify_ssl = true
 name = "pypi"
 
 [packages]
+sentry-sdk = "*"
 
 [dev-packages]
 bandit = "*"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "857ba642b3e4e9f09c59021ab5b962cc9985c9bd428c303e6f6b4e472e67df27"
+            "sha256": "32b619076665a25439478196b86231ba2ab976c300f53c4866d5abe23e0b43cc"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -15,7 +15,32 @@
             }
         ]
     },
-    "default": {},
+    "default": {
+        "certifi": {
+            "hashes": [
+                "sha256:84c85a9078b11105f04f3036a9482ae10e4621616db313fe045dd24743a0820d",
+                "sha256:fe86415d55e84719d75f8b69414f6438ac3547d2078ab91b67e779ef69378412"
+            ],
+            "markers": "python_version >= '3.6'",
+            "version": "==2022.6.15"
+        },
+        "sentry-sdk": {
+            "hashes": [
+                "sha256:0c8d2e1a02c4d438aec762cd82c1f785f6477a9436fd6279996be0b0f139dd5a",
+                "sha256:6167aa8f39d50661cee560db76b71c256a1b5ad68c3fcdc9df20c4c9b3796c8c"
+            ],
+            "index": "pypi",
+            "version": "==1.9.1"
+        },
+        "urllib3": {
+            "hashes": [
+                "sha256:c33ccba33c819596124764c23a97d25f32b28433ba0dedeb77d873a38722c9bc",
+                "sha256:ea6e8fb210b19d950fab93b60c9009226c63a28808bc8386e05301e25883ac0a"
+            ],
+            "markers": "python_version >= '3.6'",
+            "version": "==1.26.11"
+        }
+    },
     "develop": {
         "astroid": {
             "hashes": [

--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ make dist-dev
 ### Run the default handler for the container
 
 ```bash
-docker run -p 9000:8080 timdex-pipeline-lambdas-dev:latest
+docker run -e WORKSPACE=dev -p 9000:8080 timdex-pipeline-lambdas-dev:latest
 ```
 
 ### POST to the container

--- a/README.md
+++ b/README.md
@@ -2,6 +2,11 @@
 
 TIMDEX Pipeline Lambdas is a collection of lambdas used in the TIMDEX Ingest Pipeline.
 
+## Required env variables
+
+- `WORKSPACE`: set to `dev` for local development, set by Terraform on AWS.
+- `SENTRY_DSN`: only needed in production.
+
 ## Format Input Handler
 
 Takes input JSON (usually from EventBridge although it can be passed to a manual Step Function execution), and returns reformatted JSON matching the expected input data needed for the remaining steps in the TIMDEX pipeline Step Function.

--- a/lambdas/format_input.py
+++ b/lambdas/format_input.py
@@ -1,4 +1,27 @@
 import datetime
+import json
+import logging
+import os
+
+import sentry_sdk
+from sentry_sdk.integrations.aws_lambda import AwsLambdaIntegration
+
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.DEBUG)
+
+env = os.getenv("WORKSPACE")
+if sentry_dsn := os.getenv("SENTRY_DSN"):
+    sentry = sentry_sdk.init(
+        dsn=sentry_dsn,
+        environment=env,
+        integrations=[
+            AwsLambdaIntegration(),
+        ],
+        traces_sample_rate=1.0,
+    )
+    logger.info("Sentry DSN found, exceptions will be sent to Sentry with env=%s", env)
+else:
+    logger.info("No Sentry DSN found, exceptions will not be sent to Sentry")
 
 REQUIRED_FIELDS = (
     "harvest-type",
@@ -10,15 +33,16 @@ REQUIRED_FIELDS = (
 )
 
 REQUIRED_HARVEST_FIELDS = ("oai-pmh-host", "oai-metadata-format")
-
 VALID_DATE_FORMATS = ("%Y-%m-%d", "%Y-%m-%dT%H:%M:%SZ")
-
 VALID_HARVEST_TYPES = ("full", "daily")
-
 VALID_STARTING_STEPS = ("harvest", "transform", "load")
 
 
 def lambda_handler(event: dict, context: dict) -> dict:  # noqa
+    logger.debug(json.dumps(event))
+
+    if not os.getenv("WORKSPACE"):
+        raise RuntimeError("Required env variable WORKSPACE is not set")
 
     validate_input(event)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,8 @@
+import os
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def test_env():
+    os.environ = {"WORKSPACE": "test"}


### PR DESCRIPTION
### What does this PR do?

Adds Sentry integration for central exception monitoring.

### How can a reviewer manually see the effects of these changes?

In the AWS dev account lambda function console, go to the Test tab and run a test with empty JSON. Then go to Sentry and you should see a new KeyError event from the dev environment.

### Includes new or updated dependencies?

YES

### What are the relevant tickets?

- https://mitlibraries.atlassian.net/browse/IN-526

### Developer

- [x] All new ENV is documented in README (or there is none)
- [x] Stakeholder approval has been confirmed (or is not needed)

### Code Reviewer

- [ ] The commit message is clear and follows our guidelines (not just this pull request message)
- [ ] There are appropriate tests covering any new functionality
- [ ] The documentation has been updated or is unnecessary
- [ ] The changes have been verified
- [ ] New dependencies are appropriate or there were no changes
