### PR TITLE
TIMX 441 - support v2 transform command

### DIFF
--- a/lambdas/commands.py
+++ b/lambdas/commands.py
@@ -72,6 +72,7 @@ def generate_transform_commands(
     input_data: dict,
     run_date: str,
     timdex_bucket: str,
+    run_id: str,
 ) -> dict[str, list[dict]]:
     """Generate task run command for TIMDEX transform."""
     # NOTE: FEATURE FLAG: branching logic will be removed after v2 work is complete
@@ -82,7 +83,9 @@ def generate_transform_commands(
                 extract_output_files, input_data, run_date, timdex_bucket
             )
         case 2:
-            return _etl_v2_generate_transform_commands_method()
+            return _etl_v2_generate_transform_commands_method(
+                extract_output_files, input_data, timdex_bucket, run_id
+            )
 
 
 # NOTE: FEATURE FLAG: branching logic + method removed after v2 work is complete
@@ -114,8 +117,23 @@ def _etl_v1_generate_transform_commands_method(
 
 
 # NOTE: FEATURE FLAG: branching logic + method removed after v2 work is complete
-def _etl_v2_generate_transform_commands_method() -> dict[str, list[dict]]:
-    raise NotImplementedError
+def _etl_v2_generate_transform_commands_method(
+    extract_output_files: list[str],
+    input_data: dict,
+    timdex_bucket: str,
+    run_id: str,
+) -> dict[str, list[dict]]:
+    files_to_transform: list[dict] = []
+    source = input_data["source"]
+    for extract_output_file in extract_output_files:
+        transform_command = [
+            f"--input-file=s3://{timdex_bucket}/{extract_output_file}",
+            f"--output-location=s3://{timdex_bucket}/dataset",
+            f"--source={source}",
+            f"--run-id={run_id}",
+        ]
+        files_to_transform.append({"transform-command": transform_command})
+    return {"files-to-transform": files_to_transform}
 
 
 def generate_load_commands(

--- a/lambdas/config.py
+++ b/lambdas/config.py
@@ -13,6 +13,7 @@ REQUIRED_ENV = {
     "TIMDEX_S3_EXTRACT_BUCKET_ID",
     "WORKSPACE",
 }
+# NOTE: FEATURE FLAG: add "run-id" after v1 pathways are removed
 REQUIRED_FIELDS = ("next-step", "run-date", "run-type", "source")
 REQUIRED_OAI_HARVEST_FIELDS = ("oai-pmh-host", "oai-metadata-format")
 VALID_DATE_FORMATS = ("%Y-%m-%d", "%Y-%m-%dT%H:%M:%SZ")

--- a/lambdas/format_input.py
+++ b/lambdas/format_input.py
@@ -1,6 +1,7 @@
 import json
 import logging
 import os
+import uuid
 
 from lambdas import alma_prep, commands, config, errors, helpers
 
@@ -19,6 +20,7 @@ def lambda_handler(event: dict, _context: dict) -> dict:
     run_type = event["run-type"]
     source = event["source"]
     next_step = event["next-step"]
+    run_id = event.get("run-id", str(uuid.uuid4()))
     timdex_bucket = os.environ["TIMDEX_S3_EXTRACT_BUCKET_ID"]
 
     result = {
@@ -67,7 +69,7 @@ def lambda_handler(event: dict, _context: dict) -> dict:
         )
         result["next-step"] = "load"
         result["transform"] = commands.generate_transform_commands(
-            extract_output_files, event, run_date, timdex_bucket
+            extract_output_files, event, run_date, timdex_bucket, run_id
         )
 
     elif next_step == "load":

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -60,3 +60,16 @@ def mocked_s3():
 def s3_client():
     # ruff: noqa: PT022
     yield boto3.client("s3")
+
+
+@pytest.fixture
+def run_id():
+    return "run-abc-123"
+
+
+# NOTE: FEATURE FLAG: remove after v2 work is complete
+@pytest.fixture
+def etl_version_2(monkeypatch):
+    etl_version = 2
+    monkeypatch.setenv("ETL_VERSION", f"{etl_version}")
+    return etl_version

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -77,7 +77,7 @@ def test_generate_extract_command_geoharvester():
     }
 
 
-def test_generate_transform_commands_required_input_fields():
+def test_generate_transform_commands_required_input_fields(etl_version_2, run_id):
     input_data = {
         "next-step": "transform",
         "run-date": "2022-01-02T12:13:14Z",
@@ -88,23 +88,27 @@ def test_generate_transform_commands_required_input_fields():
         "testsource/testsource-2022-01-02-full-extracted-records-to-index.xml"
     ]
     assert commands.generate_transform_commands(
-        extract_output_files, input_data, "2022-01-02", "test-timdex-bucket"
+        extract_output_files,
+        input_data,
+        "2022-01-02",
+        "test-timdex-bucket",
+        run_id,
     ) == {
         "files-to-transform": [
             {
                 "transform-command": [
                     "--input-file=s3://test-timdex-bucket/testsource/"
                     "testsource-2022-01-02-full-extracted-records-to-index.xml",
-                    "--output-file=s3://test-timdex-bucket/testsource/"
-                    "testsource-2022-01-02-full-transformed-records-to-index.json",
+                    "--output-location=s3://test-timdex-bucket/dataset",
                     "--source=testsource",
+                    f"--run-id={run_id}",
                 ]
             }
         ]
     }
 
 
-def test_generate_transform_commands_all_input_fields():
+def test_generate_transform_commands_all_input_fields(etl_version_2, run_id):
     input_data = {
         "next-step": "transform",
         "run-date": "2022-01-02T12:13:14Z",
@@ -117,34 +121,34 @@ def test_generate_transform_commands_all_input_fields():
         "testsource/testsource-2022-01-02-daily-extracted-records-to-delete.xml",
     ]
     assert commands.generate_transform_commands(
-        extract_output_files, input_data, "2022-01-02", "test-timdex-bucket"
+        extract_output_files, input_data, "2022-01-02", "test-timdex-bucket", run_id
     ) == {
         "files-to-transform": [
             {
                 "transform-command": [
                     "--input-file=s3://test-timdex-bucket/testsource/"
                     "testsource-2022-01-02-daily-extracted-records-to-index_01.xml",
-                    "--output-file=s3://test-timdex-bucket/testsource/"
-                    "testsource-2022-01-02-daily-transformed-records-to-index_01.json",
+                    "--output-location=s3://test-timdex-bucket/dataset",
                     "--source=testsource",
+                    f"--run-id={run_id}",
                 ]
             },
             {
                 "transform-command": [
                     "--input-file=s3://test-timdex-bucket/testsource/"
                     "testsource-2022-01-02-daily-extracted-records-to-index_02.xml",
-                    "--output-file=s3://test-timdex-bucket/testsource/"
-                    "testsource-2022-01-02-daily-transformed-records-to-index_02.json",
+                    "--output-location=s3://test-timdex-bucket/dataset",
                     "--source=testsource",
+                    f"--run-id={run_id}",
                 ]
             },
             {
                 "transform-command": [
                     "--input-file=s3://test-timdex-bucket/testsource/"
                     "testsource-2022-01-02-daily-extracted-records-to-delete.xml",
-                    "--output-file=s3://test-timdex-bucket/testsource/"
-                    "testsource-2022-01-02-daily-transformed-records-to-delete.txt",
+                    "--output-location=s3://test-timdex-bucket/dataset",
                     "--source=testsource",
+                    f"--run-id={run_id}",
                 ]
             },
         ]

--- a/tests/test_commands_v1.py
+++ b/tests/test_commands_v1.py
@@ -1,0 +1,79 @@
+# ruff: noqa: FBT003
+
+from lambdas import commands
+
+# NOTE: FEATURE FLAG: this file can be FULLY removed after v2 work is complete
+
+
+def test_generate_transform_commands_required_input_fields(run_id):
+    input_data = {
+        "next-step": "transform",
+        "run-date": "2022-01-02T12:13:14Z",
+        "run-type": "full",
+        "source": "testsource",
+    }
+    extract_output_files = [
+        "testsource/testsource-2022-01-02-full-extracted-records-to-index.xml"
+    ]
+    assert commands.generate_transform_commands(
+        extract_output_files, input_data, "2022-01-02", "test-timdex-bucket", run_id
+    ) == {
+        "files-to-transform": [
+            {
+                "transform-command": [
+                    "--input-file=s3://test-timdex-bucket/testsource/"
+                    "testsource-2022-01-02-full-extracted-records-to-index.xml",
+                    "--output-file=s3://test-timdex-bucket/testsource/"
+                    "testsource-2022-01-02-full-transformed-records-to-index.json",
+                    "--source=testsource",
+                ]
+            }
+        ]
+    }
+
+
+def test_generate_transform_commands_all_input_fields(run_id):
+    input_data = {
+        "next-step": "transform",
+        "run-date": "2022-01-02T12:13:14Z",
+        "run-type": "daily",
+        "source": "testsource",
+    }
+    extract_output_files = [
+        "testsource/testsource-2022-01-02-daily-extracted-records-to-index_01.xml",
+        "testsource/testsource-2022-01-02-daily-extracted-records-to-index_02.xml",
+        "testsource/testsource-2022-01-02-daily-extracted-records-to-delete.xml",
+    ]
+    assert commands.generate_transform_commands(
+        extract_output_files, input_data, "2022-01-02", "test-timdex-bucket", run_id
+    ) == {
+        "files-to-transform": [
+            {
+                "transform-command": [
+                    "--input-file=s3://test-timdex-bucket/testsource/"
+                    "testsource-2022-01-02-daily-extracted-records-to-index_01.xml",
+                    "--output-file=s3://test-timdex-bucket/testsource/"
+                    "testsource-2022-01-02-daily-transformed-records-to-index_01.json",
+                    "--source=testsource",
+                ]
+            },
+            {
+                "transform-command": [
+                    "--input-file=s3://test-timdex-bucket/testsource/"
+                    "testsource-2022-01-02-daily-extracted-records-to-index_02.xml",
+                    "--output-file=s3://test-timdex-bucket/testsource/"
+                    "testsource-2022-01-02-daily-transformed-records-to-index_02.json",
+                    "--source=testsource",
+                ]
+            },
+            {
+                "transform-command": [
+                    "--input-file=s3://test-timdex-bucket/testsource/"
+                    "testsource-2022-01-02-daily-extracted-records-to-delete.xml",
+                    "--output-file=s3://test-timdex-bucket/testsource/"
+                    "testsource-2022-01-02-daily-transformed-records-to-delete.txt",
+                    "--source=testsource",
+                ]
+            },
+        ]
+    }


### PR DESCRIPTION
### Purpose and background context

This PR begins to utilize the v2 feature flag pathway for producing a transform command for Transmogrifier.

The changes are actually pretty minimal:

- retrieve `run-id` from the payload sent to pipeline lambda, minting a UUID if not present (i.e. for "v1" invocations)
- add logic to the previously stubbed `_etl_v2_generate_transform_commands_method()` function
- produce a v2 transform command for Transmogrifier

### How can a reviewer manually see the effects of these changes?

In Dev1 the SSM parameter `/apps/timdex-infrastructure/etl/version` has been set to `2`, and terraform re-applied, resulting in Transmogrifier, pipeline lambdas, and TIM getting an environment variable `ETL_VERSION=2`.  High level, this means both the [v1 StepFunction](https://us-east-1.console.aws.amazon.com/states/home?region=us-east-1#/statemachines/view/arn%3Aaws%3Astates%3Aus-east-1%3A222053980223%3AstateMachine%3Atimdex-ingest-dev?type=standard) and [v2 StepFunction](https://us-east-1.console.aws.amazon.com/states/home?region=us-east-1#/statemachines/view/arn:aws:states:us-east-1:222053980223:stateMachine:timdex-ingest-v2-dev) in Dev1 are attempting v2 runs at this time.

As such, invoking the Dev1 v2 StepFunction will trigger this new pathway in the pipeline lambdas, which send a new Transmogrifier command, which Transmogrifier then uses.

This required some [small changes to the StepFunction](https://github.com/MITLibraries/mitlib-tf-workloads-timdex-infrastructure/commit/3eeb391573f319309d513519b9a3096031cef304) as well, which now extract the StepFunction execution id and pass it to the pipeline lambdas whenever they are invoked.

[This recent run](https://us-east-1.console.aws.amazon.com/states/home?region=us-east-1#/v2/executions/details/arn:aws:states:us-east-1:222053980223:execution:timdex-ingest-v2-dev:fe6e9d6d-67f7-4250-8842-4e43ebd53c02) demonstrates this new pipeline lambdas behavior working as expected.

This screenshot shows the transform pipeline lambda invoked with a new `run-id` node:

<img width="672" alt="Screenshot 2024-12-19 at 9 35 10 AM" src="https://github.com/user-attachments/assets/201f30d4-dd51-4b13-8150-06475244960b" />

And this shows the lambda _returning_ a new Transmogrifier command with `--output-location` and `--run-id` CLI arguments included:

<img width="675" alt="Screenshot 2024-12-19 at 9 37 13 AM" src="https://github.com/user-attachments/assets/90817e2c-d531-44c9-8818-ee162c04a62e" />

Given the updates to Transmogrifier [from this PR](https://github.com/MITLibraries/transmogrifier/pull/219), Transmogrifier successfully wrote its output to the TIMDEX parquet dataset for the first time (when invoked by the StepFunction) at `s3://timdex-extract-dev-222053980223/dataset/year=2024/month=12/day=18/4cfc36e4-4bb5-4f85-aed2-cee91bcc588d-0.parquet`.

Lastly, this run of the StepFunction ultimately _failed_ because v2 behavior is not yet set for TIM.  After writing to the parquet dataset, the rest of the StepFunction was still looking for v1 files.

### Includes new or updated dependencies?
NO

### Changes expectations for external applications?
YES: if the `ETL_VERSION=2` in the TIMDEX StepFunction environment, this application and Transmogrifier will be using v2 behavior.

### What are the relevant tickets?
- https://mitlibraries.atlassian.net/browse/TIMX-441

### Developer
- [X] All new ENV is documented in README
- [X] All new ENV has been added to staging and production environments
- [ ] All related Jira tickets are linked in commit message(s)
- [X] Stakeholder approval has been confirmed (or is not needed)

### Code Reviewer(s)
- [ ] The commit message is clear and follows our guidelines (not just this PR message)
- [ ] There are appropriate tests covering any new functionality
- [ ] The provided documentation is sufficient for understanding any new functionality introduced
- [ ] Any manual tests have been performed and verified
- [ ] New dependencies are appropriate or there were no changes
