### PR TITLE
TIMX 521 - New ETL records data location

### DIFF
--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -26,62 +26,62 @@
         },
         "boto3": {
             "hashes": [
-                "sha256:0fe6b7d1974851588ec1edd39c66d9525d539133e02c7f985f9ebec5e222c0db",
-                "sha256:6f4163cd9e030afd1059e8a6daa178835165b79eb0b5325a8cd447020b895921"
+                "sha256:1a715cb40ea9df6b666148b243b5b9adbfa5be50d28e2f660330c0581d94b639",
+                "sha256:bbf7a8d374b513975c305883ae40e623cc261dbdc25ea86ae435647cae837a15"
             ],
             "index": "pypi",
             "markers": "python_version >= '3.9'",
-            "version": "==1.38.38"
+            "version": "==1.39.12"
         },
         "botocore": {
             "hashes": [
-                "sha256:aa5cc63bf885819d862852edb647d6276fe423c60113e8db375bb7ad8d88a5d9",
-                "sha256:acf9ae5b2d99c1f416f94fa5b4f8c044ecb76ffcb7fb1b1daec583f36892a8e2"
+                "sha256:60bfa0f1e0eb03997e22254e2e6a0e3f7e02b8f845253a4bb235d9240d195c72",
+                "sha256:d20b53a196af32ff153cbdbef3cb89e6a9065dc5e90ce23d009e03364601a266"
             ],
             "markers": "python_version >= '3.9'",
-            "version": "==1.38.38"
+            "version": "==1.39.12"
         },
         "duckdb": {
             "hashes": [
-                "sha256:13d20cb8248f36b999bd1cbdd63d9066d7beb40ce9e6c2040ef2d7c6947f2152",
-                "sha256:18f21142546edb5f935963f8f012b6569b978f398d48709da276b245ee4f5f4d",
-                "sha256:1ac996ac099f5d15468e33a93caf078da0fdace48c8a2c9af41e7bec766602f3",
-                "sha256:21440dd37f073944badd495c299c6d085cd133633450467ec420c71897ac1d5b",
-                "sha256:21da268355dfdf859b3d4db22180f7d5dd85a60517e077cb4158768cd5f0ee44",
-                "sha256:265979d57193fbeaf13b732a02ca9fadba76c694f2d63d87a7f136357f8c2dca",
-                "sha256:26944ff2c09749077ee63e5fec634da431b0b8eb7dd0d30c24fa7fe89ce70b66",
-                "sha256:27d775a5af405d1c228561830c8ccbe4e2832dafb4012f16c05fde1cde206dee",
-                "sha256:376193078285b243910b1239a927e271d12d9bf6358a6937d1f7af253cfef2b6",
-                "sha256:3eb045a9bf92da890d890cde2f676b3bda61b9de3b7dc46cbaaf75875b41e4b0",
-                "sha256:3ed9a942ba1167a51c0eb9f23c567051a51da4cbf920b3ac83fe63b010c4334c",
-                "sha256:57a2324f8206a52f5fd2b44f34c3746bed8bcd5e98b05b298e04fafbf30e5079",
-                "sha256:59121f0a8220b72050046a816e85e7464eb78e395f64118161b1115855284f87",
-                "sha256:591c9ca1b8dc591548bf56b2f18e26ca2339d7b95613009f6ba00af855210029",
-                "sha256:63e6757065ca24d327a9a8ebd7e0400ab3c73cd7f5876e75e9f49f3453aff793",
-                "sha256:663610b591ea6964f140441c81b718e745704cf098c540e905b200b9079e2a5c",
-                "sha256:67b1a3c9e2c3474991da97edfec0a89f382fef698d7f64b2d8d09006eaeeea24",
-                "sha256:72bbc8479c5d88e839a92c458c94c622f917ff0122853323728d6e25b0c3d4e1",
-                "sha256:73f389f9c713325a6994dd9e04a7fa23bd73e8387883f8086946a9d3a1dd70e1",
-                "sha256:77902954d15ba4aff92e82df700643b995c057f2d7d39af7ed226d8cceb9c2af",
-                "sha256:8321ecd3c6be22660ac7b48d1770781b2a9d22e3f961ad0bb9f851d4e109806c",
-                "sha256:833b3c0208c238aac0d9287fcaca93ea54b82deabd8d162a469bd9adb42a0453",
-                "sha256:8793b5abb365bbbf64ba3065f3a37951fe04f2d4506b0e24f3f8ecd08b3af4ba",
-                "sha256:87c99569274b453d8f9963e43fea74bc86901773fac945c1fe612c133a91e506",
-                "sha256:8bdd53e62917298208b7182d5fd1686a4caddc573dc1a95a58ca054105b23b38",
-                "sha256:8e101990a879533b1d33f003df2eb2a3c4bc7bdf976bd7ef7c32342047935327",
-                "sha256:937de83df6bbe4bee5830ce80f568d4c0ebf3ef5eb809db3343d2161e4f6e42b",
-                "sha256:a4d0019672cb3c1f2bbfceefdd23d14113472df3e70c5796866d6ba19a2c1575",
-                "sha256:b1d21f66e89100d7ae8353800d9525e5e24d19299b1fb099564d1106336dfdba",
-                "sha256:bf7d6884bfb67aef67aebb0bd2460ea1137c55b3fd8794a3530c653dbe0d4019",
-                "sha256:ccccc9dc9cb2269430fed29a2be8ff65a84d7b9e427548e02b5a8e1e1aacfa6d",
-                "sha256:d690576e8b4479b1e0c58cd8179f600f67af237ad31186fb10e867a02d4d66ff",
-                "sha256:ebfd06a746b0f8fb1e83bc79bfa29b4b4ebe8c095d1c790b88f4d60d58e0ebbd",
-                "sha256:f1d076b12f0d2a7f9090ad9e4057ac41af3e4785969e5997afd44922c7b141e0",
-                "sha256:f8a1ca3bbf84275ba4e0da2bccf6d43cb277a19af6f88fb86f98c33a98cce02e",
-                "sha256:fb86f0506d9e402187820030c71026b44138908feff2963ef4203f25d89296c0"
+                "sha256:003f7d36f0d8a430cb0e00521f18b7d5ee49ec98aaa541914c6d0e008c306f1a",
+                "sha256:07952ec6f45dd3c7db0f825d231232dc889f1f2490b97a4e9b7abb6830145a19",
+                "sha256:09b5fd8a112301096668903781ad5944c3aec2af27622bd80eae54149de42b42",
+                "sha256:0eb210cedf08b067fa90c666339688f1c874844a54708562282bc54b0189aac6",
+                "sha256:10cb87ad964b989175e7757d7ada0b1a7264b401a79be2f828cf8f7c366f7f95",
+                "sha256:11af73963ae174aafd90ea45fb0317f1b2e28a7f1d9902819d47c67cc957d49c",
+                "sha256:14676651b86f827ea10bf965eec698b18e3519fdc6266d4ca849f5af7a8c315e",
+                "sha256:186fc3f98943e97f88a1e501d5720b11214695571f2c74745d6e300b18bef80e",
+                "sha256:18862e3b8a805f2204543d42d5f103b629cb7f7f2e69f5188eceb0b8a023f0af",
+                "sha256:1c90646b52a0eccda1f76b10ac98b502deb9017569e84073da00a2ab97763578",
+                "sha256:1d57df2149d6e4e0bd5198689316c5e2ceec7f6ac0a9ec11bc2b216502a57b34",
+                "sha256:2455b1ffef4e3d3c7ef8b806977c0e3973c10ec85aa28f08c993ab7f2598e8dd",
+                "sha256:2a741eae2cf110fd2223eeebe4151e22c0c02803e1cfac6880dbe8a39fecab6a",
+                "sha256:3380aae1c4f2af3f37b0bf223fabd62077dd0493c84ef441e69b45167188e7b6",
+                "sha256:36abdfe0d1704fe09b08d233165f312dad7d7d0ecaaca5fb3bb869f4838a2d0b",
+                "sha256:4389fc3812e26977034fe3ff08d1f7dbfe6d2d8337487b4686f2b50e254d7ee3",
+                "sha256:45bea70b3e93c6bf766ce2f80fc3876efa94c4ee4de72036417a7bd1e32142fe",
+                "sha256:4732fb8cc60566b60e7e53b8c19972cb5ed12d285147a3063b16cc64a79f6d9f",
+                "sha256:4cdffb1e60defbfa75407b7f2ccc322f535fd462976940731dfd1644146f90c6",
+                "sha256:51e62541341ea1a9e31f0f1ade2496a39b742caf513bebd52396f42ddd6525a0",
+                "sha256:54f76c8b1e2a19dfe194027894209ce9ddb073fd9db69af729a524d2860e4680",
+                "sha256:6b7e6bb613b73745f03bff4bb412f362d4a1e158bdcb3946f61fd18e9e1a8ddf",
+                "sha256:72ca6143d23c0bf6426396400f01fcbe4785ad9ceec771bd9a4acc5b5ef9a075",
+                "sha256:75ed129761b6159f0b8eca4854e496a3c4c416e888537ec47ff8eb35fda2b667",
+                "sha256:84a19f185ee0c5bc66d95908c6be19103e184b743e594e005dee6f84118dc22c",
+                "sha256:875193ae9f718bc80ab5635435de5b313e3de3ec99420a9b25275ddc5c45ff58",
+                "sha256:97f7a22dcaa1cca889d12c3dc43a999468375cdb6f6fe56edf840e062d4a8293",
+                "sha256:9d0ae509713da3461c000af27496d5413f839d26111d2a609242d9d17b37d464",
+                "sha256:a3418c973b06ac4e97f178f803e032c30c9a9f56a3e3b43a866f33223dfbf60b",
+                "sha256:b3e519de5640e5671f1731b3ae6b496e0ed7e4de4a1c25c7a2f34c991ab64d71",
+                "sha256:b49a11afba36b98436db83770df10faa03ebded06514cb9b180b513d8be7f392",
+                "sha256:c658df8a1bc78704f702ad0d954d82a1edd4518d7a04f00027ec53e40f591ff5",
+                "sha256:cd3d717bf9c49ef4b1016c2216517572258fa645c2923e91c5234053defa3fb5",
+                "sha256:db256c206056468ae6a9e931776bdf7debaffc58e19a0ff4fa9e7e1e82d38b3b",
+                "sha256:e1872cf63aae28c3f1dc2e19b5e23940339fc39fb3425a06196c5d00a8d01040",
+                "sha256:e584f25892450757919639b148c2410402b17105bd404017a57fa9eec9c98919"
             ],
             "markers": "python_full_version >= '3.7.0'",
-            "version": "==1.3.1"
+            "version": "==1.3.2"
         },
         "jmespath": {
             "hashes": [
@@ -93,169 +93,157 @@
         },
         "numpy": {
             "hashes": [
-                "sha256:06d4fb37a8d383b769281714897420c5cc3545c79dc427df57fc9b852ee0bf58",
-                "sha256:0898c67a58cdaaf29994bc0e2c65230fd4de0ac40afaf1584ed0b02cd74c6fdd",
-                "sha256:0eba4a1ea88f9a6f30f56fdafdeb8da3774349eacddab9581a21234b8535d3d3",
-                "sha256:2393a914db64b0ead0ab80c962e42d09d5f385802006a6c87835acb1f58adb96",
-                "sha256:2e6a1409eee0cb0316cb64640a49a49ca44deb1a537e6b1121dc7c458a1299a8",
-                "sha256:33a5a12a45bb82d9997e2c0b12adae97507ad7c347546190a18ff14c28bbca12",
-                "sha256:389b85335838155a9076e9ad7f8fdba0827496ec2d2dc32ce69ce7898bde03ba",
-                "sha256:39b27d8b38942a647f048b675f134dd5a567f95bfff481f9109ec308515c51d8",
-                "sha256:43c55b6a860b0eb44d42341438b03513cf3879cb3617afb749ad49307e164edd",
-                "sha256:46d16f72c2192da7b83984aa5455baee640e33a9f1e61e656f29adf55e406c2b",
-                "sha256:48a2e8eaf76364c32a1feaa60d6925eaf32ed7a040183b807e02674305beef61",
-                "sha256:4d8d294287fdf685281e671886c6dcdf0291a7c19db3e5cb4178d07ccf6ecc67",
-                "sha256:4dc58865623023b63b10d52f18abaac3729346a7a46a778381e0e3af4b7f3beb",
-                "sha256:50080245365d75137a2bf46151e975de63146ae6d79f7e6bd5c0e85c9931d06a",
-                "sha256:54dfc8681c1906d239e95ab1508d0a533c4a9505e52ee2d71a5472b04437ef97",
-                "sha256:5754ab5595bfa2c2387d241296e0381c21f44a4b90a776c3c1d39eede13a746a",
-                "sha256:5814a0f43e70c061f47abd5857d120179609ddc32a613138cbb6c4e9e2dbdda5",
-                "sha256:581f87f9e9e9db2cba2141400e160e9dd644ee248788d6f90636eeb8fd9260a6",
-                "sha256:622a65d40d8eb427d8e722fd410ac3ad4958002f109230bc714fa551044ebae2",
-                "sha256:6295f81f093b7f5769d1728a6bd8bf7466de2adfa771ede944ce6711382b89dc",
-                "sha256:690d0a5b60a47e1f9dcec7b77750a4854c0d690e9058b7bef3106e3ae9117808",
-                "sha256:7729c8008d55e80784bd113787ce876ca117185c579c0d626f59b87d433ea779",
-                "sha256:80b46117c7359de8167cc00a2c7d823bdd505e8c7727ae0871025a86d668283b",
-                "sha256:81ae0bf2564cf475f94be4a27ef7bcf8af0c3e28da46770fc904da9abd5279b5",
-                "sha256:87717eb24d4a8a64683b7a4e91ace04e2f5c7c77872f823f02a94feee186168f",
-                "sha256:8b51ead2b258284458e570942137155978583e407babc22e3d0ed7af33ce06f8",
-                "sha256:9498f60cd6bb8238d8eaf468a3d5bb031d34cd12556af53510f05fcf581c1b7e",
-                "sha256:99224862d1412d2562248d4710126355d3a8db7672170a39d6909ac47687a8a4",
-                "sha256:a0be278be9307c4ab06b788f2a077f05e180aea817b3e41cebbd5aaf7bd85ed3",
-                "sha256:aaf81c7b82c73bd9b45e79cfb9476cb9c29e937494bfe9092c26aece812818ad",
-                "sha256:aba48d17e87688a765ab1cd557882052f238e2f36545dfa8e29e6a91aef77afe",
-                "sha256:b0f1f11d0a1da54927436505a5a7670b154eac27f5672afc389661013dfe3d4f",
-                "sha256:b9446d9d8505aadadb686d51d838f2b6688c9e85636a0c3abaeb55ed54756459",
-                "sha256:ba17f93a94e503551f154de210e4d50c5e3ee20f7e7a1b5f6ce3f22d419b93bb",
-                "sha256:bd8df082b6c4695753ad6193018c05aac465d634834dca47a3ae06d4bb22d9ea",
-                "sha256:c24bb4113c66936eeaa0dc1e47c74770453d34f46ee07ae4efd853a2ed1ad10a",
-                "sha256:c39ec392b5db5088259c68250e342612db82dc80ce044cf16496cf14cf6bc6f8",
-                "sha256:c3c9fdde0fa18afa1099d6257eb82890ea4f3102847e692193b54e00312a9ae9",
-                "sha256:c8738baa52505fa6e82778580b23f945e3578412554d937093eac9205e845e6e",
-                "sha256:d11fa02f77752d8099573d64e5fe33de3229b6632036ec08f7080f46b6649959",
-                "sha256:d344ca32ab482bcf8735d8f95091ad081f97120546f3d250240868430ce52555",
-                "sha256:d8fa264d56882b59dcb5ea4d6ab6f31d0c58a57b41aec605848b6eb2ef4a43e8",
-                "sha256:df470d376f54e052c76517393fa443758fefcdd634645bc9c1f84eafc67087f0",
-                "sha256:e017a8a251ff4d18d71f139e28bdc7c31edba7a507f72b1414ed902cbe48c74d",
-                "sha256:e43c3cce3b6ae5f94696669ff2a6eafd9a6b9332008bafa4117af70f4b88be6f",
-                "sha256:e651756066a0eaf900916497e20e02fe1ae544187cb0fe88de981671ee7f6270",
-                "sha256:e6648078bdd974ef5d15cecc31b0c410e2e24178a6e10bf511e0557eed0f2570",
-                "sha256:ee9d3ee70d62827bc91f3ea5eee33153212c41f639918550ac0475e3588da59f",
-                "sha256:ef6c1e88fd6b81ac6d215ed71dc8cd027e54d4bf1d2682d362449097156267a2",
-                "sha256:f14e016d9409680959691c109be98c436c6249eaf7f118b424679793607b5944",
-                "sha256:f420033a20b4f6a2a11f585f93c843ac40686a7c3fa514060a97d9de93e5e72b"
+                "sha256:0025048b3c1557a20bc80d06fdeb8cc7fc193721484cca82b2cfa072fec71a93",
+                "sha256:010ce9b4f00d5c036053ca684c77441f2f2c934fd23bee058b4d6f196efd8280",
+                "sha256:0bb3a4a61e1d327e035275d2a993c96fa786e4913aa089843e6a2d9dd205c66a",
+                "sha256:0c4d9e0a8368db90f93bd192bfa771ace63137c3488d198ee21dfb8e7771916e",
+                "sha256:15aa4c392ac396e2ad3d0a2680c0f0dee420f9fed14eef09bdb9450ee6dcb7b7",
+                "sha256:18703df6c4a4fee55fd3d6e5a253d01c5d33a295409b03fda0c86b3ca2ff41a1",
+                "sha256:1ec9ae20a4226da374362cca3c62cd753faf2f951440b0e3b98e93c235441d2b",
+                "sha256:23ab05b2d241f76cb883ce8b9a93a680752fbfcbd51c50eff0b88b979e471d8c",
+                "sha256:25a1992b0a3fdcdaec9f552ef10d8103186f5397ab45e2d25f8ac51b1a6b97e8",
+                "sha256:2959d8f268f3d8ee402b04a9ec4bb7604555aeacf78b360dc4ec27f1d508177d",
+                "sha256:2a809637460e88a113e186e87f228d74ae2852a2e0c44de275263376f17b5bdc",
+                "sha256:2fb86b7e58f9ac50e1e9dd1290154107e47d1eef23a0ae9145ded06ea606f992",
+                "sha256:36890eb9e9d2081137bd78d29050ba63b8dab95dff7912eadf1185e80074b2a0",
+                "sha256:39bff12c076812595c3a306f22bfe49919c5513aa1e0e70fac756a0be7c2a2b8",
+                "sha256:467db865b392168ceb1ef1ffa6f5a86e62468c43e0cfb4ab6da667ede10e58db",
+                "sha256:4e602e1b8682c2b833af89ba641ad4176053aaa50f5cacda1a27004352dde943",
+                "sha256:5902660491bd7a48b2ec16c23ccb9124b8abfd9583c5fdfa123fe6b421e03de1",
+                "sha256:5ccb7336eaf0e77c1635b232c141846493a588ec9ea777a7c24d7166bb8533ae",
+                "sha256:5f1b8f26d1086835f442286c1d9b64bb3974b0b1e41bb105358fd07d20872952",
+                "sha256:6269b9edfe32912584ec496d91b00b6d34282ca1d07eb10e82dfc780907d6c2e",
+                "sha256:6ea9e48336a402551f52cd8f593343699003d2353daa4b72ce8d34f66b722070",
+                "sha256:762e0c0c6b56bdedfef9a8e1d4538556438288c4276901ea008ae44091954e29",
+                "sha256:7be91b2239af2658653c5bb6f1b8bccafaf08226a258caf78ce44710a0160d30",
+                "sha256:7dea630156d39b02a63c18f508f85010230409db5b2927ba59c8ba4ab3e8272e",
+                "sha256:867ef172a0976aaa1f1d1b63cf2090de8b636a7674607d514505fb7276ab08fc",
+                "sha256:8d5ee6eec45f08ce507a6570e06f2f879b374a552087a4179ea7838edbcbfa42",
+                "sha256:8e333040d069eba1652fb08962ec5b76af7f2c7bce1df7e1418c8055cf776f25",
+                "sha256:a5ee121b60aa509679b682819c602579e1df14a5b07fe95671c8849aad8f2115",
+                "sha256:a780033466159c2270531e2b8ac063704592a0bc62ec4a1b991c7c40705eb0e8",
+                "sha256:a894f3816eb17b29e4783e5873f92faf55b710c2519e5c351767c51f79d8526d",
+                "sha256:a8b740f5579ae4585831b3cf0e3b0425c667274f82a484866d2adf9570539369",
+                "sha256:ad506d4b09e684394c42c966ec1527f6ebc25da7f4da4b1b056606ffe446b8a3",
+                "sha256:afed2ce4a84f6b0fc6c1ce734ff368cbf5a5e24e8954a338f3bdffa0718adffb",
+                "sha256:b0b5397374f32ec0649dd98c652a1798192042e715df918c20672c62fb52d4b8",
+                "sha256:bada6058dd886061f10ea15f230ccf7dfff40572e99fef440a4a857c8728c9c0",
+                "sha256:c4913079974eeb5c16ccfd2b1f09354b8fed7e0d6f2cab933104a09a6419b1ee",
+                "sha256:c5bdf2015ccfcee8253fb8be695516ac4457c743473a43290fd36eba6a1777eb",
+                "sha256:c6e0bf9d1a2f50d2b65a7cf56db37c095af17b59f6c132396f7c6d5dd76484df",
+                "sha256:ce2ce9e5de4703a673e705183f64fd5da5bf36e7beddcb63a25ee2286e71ca48",
+                "sha256:cfecc7822543abdea6de08758091da655ea2210b8ffa1faf116b940693d3df76",
+                "sha256:d4580adadc53311b163444f877e0789f1c8861e2698f6b2a4ca852fda154f3ff",
+                "sha256:d70f20df7f08b90a2062c1f07737dd340adccf2068d0f1b9b3d56e2038979fee",
+                "sha256:e344eb79dab01f1e838ebb67aab09965fb271d6da6b00adda26328ac27d4a66e",
+                "sha256:e610832418a2bc09d974cc9fecebfa51e9532d6190223bc5ef6a7402ebf3b5cb",
+                "sha256:e772dda20a6002ef7061713dc1e2585bc1b534e7909b2030b5a46dae8ff077ab",
+                "sha256:e7cbf5a5eafd8d230a3ce356d892512185230e4781a361229bd902ff403bc660",
+                "sha256:eabd7e8740d494ce2b4ea0ff05afa1b7b291e978c0ae075487c51e8bd93c0c68",
+                "sha256:ebb8603d45bc86bbd5edb0d63e52c5fd9e7945d3a503b77e486bd88dde67a19b",
+                "sha256:ec0bdafa906f95adc9a0c6f26a4871fa753f25caaa0e032578a30457bff0af6a",
+                "sha256:eccb9a159db9aed60800187bc47a6d3451553f0e1b08b068d8b277ddfbb9b244",
+                "sha256:ee8340cb48c9b7a5899d1149eece41ca535513a9698098edbade2a8e7a84da77"
             ],
             "markers": "python_version >= '3.11'",
-            "version": "==2.3.0"
+            "version": "==2.3.1"
         },
         "pandas": {
             "hashes": [
-                "sha256:034abd6f3db8b9880aaee98f4f5d4dbec7c4829938463ec046517220b2f8574e",
-                "sha256:094e271a15b579650ebf4c5155c05dcd2a14fd4fdd72cf4854b2f7ad31ea30be",
-                "sha256:14a0cc77b0f089d2d2ffe3007db58f170dae9b9f54e569b299db871a3ab5bf46",
-                "sha256:1a881bc1309f3fce34696d07b00f13335c41f5f5a8770a33b09ebe23261cfc67",
-                "sha256:1d2b33e68d0ce64e26a4acc2e72d747292084f4e8db4c847c6f5f6cbe56ed6d8",
-                "sha256:213cd63c43263dbb522c1f8a7c9d072e25900f6975596f883f4bebd77295d4f3",
-                "sha256:23c2b2dc5213810208ca0b80b8666670eb4660bbfd9d45f58592cc4ddcfd62e1",
-                "sha256:2c7e2fc25f89a49a11599ec1e76821322439d90820108309bf42130d2f36c983",
-                "sha256:2eb4728a18dcd2908c7fccf74a982e241b467d178724545a48d0caf534b38ebf",
-                "sha256:34600ab34ebf1131a7613a260a61dbe8b62c188ec0ea4c296da7c9a06b004133",
-                "sha256:39ff73ec07be5e90330cc6ff5705c651ace83374189dcdcb46e6ff54b4a72cd6",
-                "sha256:404d681c698e3c8a40a61d0cd9412cc7364ab9a9cc6e144ae2992e11a2e77a20",
-                "sha256:40cecc4ea5abd2921682b57532baea5588cc5f80f0231c624056b146887274d2",
-                "sha256:430a63bae10b5086995db1b02694996336e5a8ac9a96b4200572b413dfdfccb9",
-                "sha256:4930255e28ff5545e2ca404637bcc56f031893142773b3468dc021c6c32a1390",
-                "sha256:6021910b086b3ca756755e86ddc64e0ddafd5e58e076c72cb1585162e5ad259b",
-                "sha256:625466edd01d43b75b1883a64d859168e4556261a5035b32f9d743b67ef44634",
-                "sha256:75651c14fde635e680496148a8526b328e09fe0572d9ae9b638648c46a544ba3",
-                "sha256:84141f722d45d0c2a89544dd29d35b3abfc13d2250ed7e68394eda7564bd6324",
-                "sha256:8adff9f138fc614347ff33812046787f7d43b3cef7c0f0171b3340cae333f6ca",
-                "sha256:951805d146922aed8357e4cc5671b8b0b9be1027f0619cea132a9f3f65f2f09c",
-                "sha256:9efc0acbbffb5236fbdf0409c04edce96bec4bdaa649d49985427bd1ec73e085",
-                "sha256:9ff730713d4c4f2f1c860e36c005c7cefc1c7c80c21c0688fd605aa43c9fcf09",
-                "sha256:a6872d695c896f00df46b71648eea332279ef4077a409e2fe94220208b6bb675",
-                "sha256:b198687ca9c8529662213538a9bb1e60fa0bf0f6af89292eb68fea28743fcd5a",
-                "sha256:b9d8c3187be7479ea5c3d30c32a5d73d62a621166675063b2edd21bc47614027",
-                "sha256:ba24af48643b12ffe49b27065d3babd52702d95ab70f50e1b34f71ca703e2c0d",
-                "sha256:bb32dc743b52467d488e7a7c8039b821da2826a9ba4f85b89ea95274f863280f",
-                "sha256:bb3be958022198531eb7ec2008cfc78c5b1eed51af8600c6c5d9160d89d8d249",
-                "sha256:bf5be867a0541a9fb47a4be0c5790a4bccd5b77b92f0a59eeec9375fafc2aa14",
-                "sha256:c06f6f144ad0a1bf84699aeea7eff6068ca5c63ceb404798198af7eb86082e33",
-                "sha256:c6da97aeb6a6d233fb6b17986234cc723b396b50a3c6804776351994f2a658fd",
-                "sha256:e0f51973ba93a9f97185049326d75b942b9aeb472bec616a129806facb129ebb",
-                "sha256:e1991bbb96f4050b09b5f811253c4f3cf05ee89a589379aa36cd623f21a31d6f",
-                "sha256:e5f08eb9a445d07720776df6e641975665c9ea12c9d8a331e0f6890f2dcd76ef",
-                "sha256:e78ad363ddb873a631e92a3c063ade1ecfb34cae71e9a2be6ad100f875ac1042",
-                "sha256:ed16339bc354a73e0a609df36d256672c7d296f3f767ac07257801aa064ff73c",
-                "sha256:f4dd97c19bd06bc557ad787a15b6489d2614ddaab5d104a0310eb314c724b2d2",
-                "sha256:f925f1ef673b4bd0271b1809b72b3270384f2b7d9d14a189b12b7fc02574d575",
-                "sha256:f95a2aef32614ed86216d3c450ab12a4e82084e8102e355707a1d96e33d51c34",
-                "sha256:fa07e138b3f6c04addfeaf56cc7fdb96c3b68a3fe5e5401251f231fce40a0d7a",
-                "sha256:fa35c266c8cd1a67d75971a1912b185b492d257092bdd2709bbdebe574ed228d"
+                "sha256:025e92411c16cbe5bb2a4abc99732a6b132f439b8aab23a59fa593eb00704232",
+                "sha256:09e3b1587f0f3b0913e21e8b32c3119174551deb4a4eba4a89bc7377947977e7",
+                "sha256:0a95b9ac964fe83ce317827f80304d37388ea77616b1425f0ae41c9d2d0d7bb2",
+                "sha256:0f951fbb702dacd390561e0ea45cdd8ecfa7fb56935eb3dd78e306c19104b9b0",
+                "sha256:1b916a627919a247d865aed068eb65eb91a344b13f5b57ab9f610b7716c92de1",
+                "sha256:1c78cf43c8fde236342a1cb2c34bcff89564a7bfed7e474ed2fffa6aed03a956",
+                "sha256:1d12f618d80379fde6af007f65f0c25bd3e40251dbd1636480dfffce2cf1e6da",
+                "sha256:22c2e866f7209ebc3a8f08d75766566aae02bcc91d196935a1d9e59c7b990ac9",
+                "sha256:2323294c73ed50f612f67e2bf3ae45aea04dce5690778e08a09391897f35ff88",
+                "sha256:2b0540963d83431f5ce8870ea02a7430adca100cec8a050f0811f8e31035541b",
+                "sha256:2ba6aff74075311fc88504b1db890187a3cd0f887a5b10f5525f8e2ef55bfdb9",
+                "sha256:2eb789ae0274672acbd3c575b0598d213345660120a257b47b5dafdc618aec83",
+                "sha256:2f4d6feeba91744872a600e6edbbd5b033005b431d5ae8379abee5bcfa479fab",
+                "sha256:342e59589cc454aaff7484d75b816a433350b3d7964d7847327edda4d532a2e3",
+                "sha256:3462c3735fe19f2638f2c3a40bd94ec2dc5ba13abbb032dd2fa1f540a075509d",
+                "sha256:3583d348546201aff730c8c47e49bc159833f971c2899d6097bce68b9112a4f1",
+                "sha256:4645f770f98d656f11c69e81aeb21c6fca076a44bed3dcbb9396a4311bc7f6d8",
+                "sha256:4d544806b485ddf29e52d75b1f559142514e60ef58a832f74fb38e48d757b299",
+                "sha256:56a342b231e8862c96bdb6ab97170e203ce511f4d0429589c8ede1ee8ece48b8",
+                "sha256:5db9637dbc24b631ff3707269ae4559bce4b7fd75c1c4d7e13f40edc42df4444",
+                "sha256:689968e841136f9e542020698ee1c4fbe9caa2ed2213ae2388dc7b81721510d3",
+                "sha256:6de8547d4fdb12421e2d047a2c446c623ff4c11f47fddb6b9169eb98ffba485a",
+                "sha256:6f3bf5ec947526106399a9e1d26d40ee2b259c66422efdf4de63c848492d91bb",
+                "sha256:782647ddc63c83133b2506912cc6b108140a38a37292102aaa19c81c83db2928",
+                "sha256:7dcb79bf373a47d2a40cf7232928eb7540155abbc460925c2c96d2d30b006eb4",
+                "sha256:8dfc17328e8da77be3cf9f47509e5637ba8f137148ed0e9b5241e1baf526e20a",
+                "sha256:9026bd4a80108fac2239294a15ef9003c4ee191a0f64b90f170b40cfb7cf2d22",
+                "sha256:911580460fc4884d9b05254b38a6bfadddfcc6aaef856fb5859e7ca202e45275",
+                "sha256:98bcc8b5bf7afed22cc753a28bc4d9e26e078e777066bc53fac7904ddef9a678",
+                "sha256:9b7ff55f31c4fcb3e316e8f7fa194566b286d6ac430afec0d461163312c5841e",
+                "sha256:ac942bfd0aca577bef61f2bc8da8147c4ef6879965ef883d8e8d5d2dc3e744b8",
+                "sha256:b3cd4273d3cb3707b6fffd217204c52ed92859533e31dc03b7c5008aa933aaab",
+                "sha256:b4b0de34dc8499c2db34000ef8baad684cfa4cbd836ecee05f323ebfba348c7d",
+                "sha256:ca7ed14832bce68baef331f4d7f294411bed8efd032f8109d690df45e00c4679",
+                "sha256:cd05b72ec02ebfb993569b4931b2e16fbb4d6ad6ce80224a3ee838387d83a191",
+                "sha256:dd71c47a911da120d72ef173aeac0bf5241423f9bfea57320110a978457e069e",
+                "sha256:e5635178b387bd2ba4ac040f82bc2ef6e6b500483975c4ebacd34bec945fda12",
+                "sha256:e6723a27ad7b244c0c79d8e7007092d7c8f0f11305770e2f4cd778b3ad5f9f85",
+                "sha256:ec6c851509364c59a5344458ab935e6451b31b818be467eb24b0fe89bd05b6b9",
+                "sha256:fe37e757f462d31a9cd7580236a82f353f5713a80e059a29753cf938c6775d96",
+                "sha256:fe67dc676818c186d5a3d5425250e40f179c2a89145df477dd82945eaea89e97",
+                "sha256:fe7317f578c6a153912bd2292f02e40c1d8f253e93c599e82620c7f69755c74f"
             ],
             "markers": "python_version >= '3.9'",
-            "version": "==2.3.0"
+            "version": "==2.3.1"
         },
         "pyarrow": {
             "hashes": [
-                "sha256:00138f79ee1b5aca81e2bdedb91e3739b987245e11fa3c826f9e57c5d102fb75",
-                "sha256:11529a2283cb1f6271d7c23e4a8f9f8b7fd173f7360776b668e509d712a02eec",
-                "sha256:15aa1b3b2587e74328a730457068dc6c89e6dcbf438d4369f572af9d320a25ee",
-                "sha256:1bcbe471ef3349be7714261dea28fe280db574f9d0f77eeccc195a2d161fd861",
-                "sha256:204a846dca751428991346976b914d6d2a82ae5b8316a6ed99789ebf976551e6",
-                "sha256:211d5e84cecc640c7a3ab900f930aaff5cd2702177e0d562d426fb7c4f737781",
-                "sha256:24ca380585444cb2a31324c546a9a56abbe87e26069189e14bdba19c86c049f0",
-                "sha256:2c3a01f313ffe27ac4126f4c2e5ea0f36a5fc6ab51f8726cf41fee4b256680bd",
-                "sha256:30b3051b7975801c1e1d387e17c588d8ab05ced9b1e14eec57915f79869b5031",
-                "sha256:3346babb516f4b6fd790da99b98bed9708e3f02e734c84971faccb20736848dc",
-                "sha256:3e1f8a47f4b4ae4c69c4d702cfbdfe4d41e18e5c7ef6f1bb1c50918c1e81c57b",
-                "sha256:4250e28a22302ce8692d3a0e8ec9d9dde54ec00d237cff4dfa9c1fbf79e472a8",
-                "sha256:4680f01ecd86e0dd63e39eb5cd59ef9ff24a9d166db328679e36c108dc993d4c",
-                "sha256:4a8b029a07956b8d7bd742ffca25374dd3f634b35e46cc7a7c3fa4c75b297191",
-                "sha256:4ba3cf4182828be7a896cbd232aa8dd6a31bd1f9e32776cc3796c012855e1199",
-                "sha256:5605919fbe67a7948c1f03b9f3727d82846c053cd2ce9303ace791855923fd20",
-                "sha256:5f0fb1041267e9968c6d0d2ce3ff92e3928b243e2b6d11eeb84d9ac547308232",
-                "sha256:6102b4864d77102dbbb72965618e204e550135a940c2534711d5ffa787df2a5a",
-                "sha256:6415a0d0174487456ddc9beaead703d0ded5966129fa4fd3114d76b5d1c5ceae",
-                "sha256:6bb830757103a6cb300a04610e08d9636f0cd223d32f388418ea893a3e655f1c",
-                "sha256:6fc1499ed3b4b57ee4e090e1cea6eb3584793fe3d1b4297bbf53f09b434991a5",
-                "sha256:75a51a5b0eef32727a247707d4755322cb970be7e935172b6a3a9f9ae98404ba",
-                "sha256:7a3a5dcf54286e6141d5114522cf31dd67a9e7c9133d150799f30ee302a7a1ab",
-                "sha256:7f4c8534e2ff059765647aa69b75d6543f9fef59e2cd4c6d18015192565d2b70",
-                "sha256:82f1ee5133bd8f49d31be1299dc07f585136679666b502540db854968576faf9",
-                "sha256:851c6a8260ad387caf82d2bbf54759130534723e37083111d4ed481cb253cc0d",
-                "sha256:89e030dc58fc760e4010148e6ff164d2f44441490280ef1e97a542375e41058e",
-                "sha256:95b330059ddfdc591a3225f2d272123be26c8fa76e8c9ee1a77aad507361cfdb",
-                "sha256:96d6a0a37d9c98be08f5ed6a10831d88d52cac7b13f5287f1e0f625a0de8062b",
-                "sha256:96e37f0766ecb4514a899d9a3554fadda770fb57ddf42b63d80f14bc20aa7db3",
-                "sha256:97c8dc984ed09cb07d618d57d8d4b67a5100a30c3818c2fb0b04599f0da2de7b",
-                "sha256:991f85b48a8a5e839b2128590ce07611fae48a904cae6cab1f089c5955b57eb5",
-                "sha256:9965a050048ab02409fb7cbbefeedba04d3d67f2cc899eff505cc084345959ca",
-                "sha256:9b71daf534f4745818f96c214dbc1e6124d7daf059167330b610fc69b6f3d3e3",
-                "sha256:a15532e77b94c61efadde86d10957950392999503b3616b2ffcef7621a002893",
-                "sha256:a18a14baef7d7ae49247e75641fd8bcbb39f44ed49a9fc4ec2f65d5031aa3b96",
-                "sha256:a1f60dc14658efaa927f8214734f6a01a806d7690be4b3232ba526836d216122",
-                "sha256:a2791f69ad72addd33510fec7bb14ee06c2a448e06b649e264c094c5b5f7ce28",
-                "sha256:a5704f29a74b81673d266e5ec1fe376f060627c2e42c5c7651288ed4b0db29e9",
-                "sha256:a6ad3e7758ecf559900261a4df985662df54fb7fdb55e8e3b3aa99b23d526b62",
-                "sha256:aa0d288143a8585806e3cc7c39566407aab646fb9ece164609dac1cfff45f6ae",
-                "sha256:b6953f0114f8d6f3d905d98e987d0924dabce59c3cda380bdfaa25a6201563b4",
-                "sha256:b8ff87cc837601532cc8242d2f7e09b4e02404de1b797aee747dd4ba4bd6313f",
-                "sha256:c7dd06fd7d7b410ca5dc839cc9d485d2bc4ae5240851bcd45d85105cc90a47d7",
-                "sha256:ca151afa4f9b7bc45bcc791eb9a89e90a9eb2772767d0b1e5389609c7d03db63",
-                "sha256:cb497649e505dc36542d0e68eca1a3c94ecbe9799cb67b578b55f2441a247fbc",
-                "sha256:d5382de8dc34c943249b01c19110783d0d64b207167c728461add1ecc2db88e4",
-                "sha256:db53390eaf8a4dab4dbd6d93c85c5cf002db24902dbff0ca7d988beb5c9dd15b",
-                "sha256:dd43f58037443af715f34f1322c782ec463a3c8a94a85fdb2d987ceb5658e061",
-                "sha256:e22f80b97a271f0a7d9cd07394a7d348f80d3ac63ed7cc38b6d1b696ab3b2619",
-                "sha256:e724a3fd23ae5b9c010e7be857f4405ed5e679db5c93e66204db1a69f733936a",
-                "sha256:e8b88758f9303fa5a83d6c90e176714b2fd3852e776fc2d7e42a22dd6c2fb368",
-                "sha256:f2d67ac28f57a362f1a2c1e6fa98bfe2f03230f7e15927aecd067433b1e70ce8",
-                "sha256:f3b117b922af5e4c6b9a9115825726cac7d8b1421c37c2b5e24fbacc8930612c",
-                "sha256:febc4a913592573c8d5805091a6c2b5064c8bd6e002131f01061797d91c783c1"
+                "sha256:067c66ca29aaedae08218569a114e413b26e742171f526e828e1064fcdec13f4",
+                "sha256:072116f65604b822a7f22945a7a6e581cfa28e3454fdcc6939d4ff6090126623",
+                "sha256:0c4e75d13eb76295a49e0ea056eb18dbd87d81450bfeb8afa19a7e5a75ae2ad7",
+                "sha256:186aa00bca62139f75b7de8420f745f2af12941595bbbfa7ed3870ff63e25636",
+                "sha256:1e005378c4a2c6db3ada3ad4c217b381f6c886f0a80d6a316fe586b90f77efd7",
+                "sha256:203003786c9fd253ebcafa44b03c06983c9c8d06c3145e37f1b76a1f317aeae1",
+                "sha256:222c39e2c70113543982c6b34f3077962b44fca38c0bd9e68bb6781534425c10",
+                "sha256:26bfd95f6bff443ceae63c65dc7e048670b7e98bc892210acba7e4995d3d4b51",
+                "sha256:3a302f0e0963db37e0a24a70c56cf91a4faa0bca51c23812279ca2e23481fccd",
+                "sha256:3a81486adc665c7eb1a2bde0224cfca6ceaba344a82a971ef059678417880eb8",
+                "sha256:3b4d97e297741796fead24867a8dabf86c87e4584ccc03167e4a811f50fdf74d",
+                "sha256:40ebfcb54a4f11bcde86bc586cbd0272bac0d516cfa539c799c2453768477569",
+                "sha256:479ee41399fcddc46159a551705b89c05f11e8b8cb8e968f7fec64f62d91985e",
+                "sha256:5051f2dccf0e283ff56335760cbc8622cf52264d67e359d5569541ac11b6d5bc",
+                "sha256:555ca6935b2cbca2c0e932bedd853e9bc523098c39636de9ad4693b5b1df86d6",
+                "sha256:585e7224f21124dd57836b1530ac8f2df2afc43c861d7bf3d58a4870c42ae36c",
+                "sha256:58c30a1729f82d201627c173d91bd431db88ea74dcaa3885855bc6203e433b82",
+                "sha256:6299449adf89df38537837487a4f8d3bd91ec94354fdd2a7d30bc11c48ef6e79",
+                "sha256:65f8e85f79031449ec8706b74504a316805217b35b6099155dd7e227eef0d4b6",
+                "sha256:689f448066781856237eca8d1975b98cace19b8dd2ab6145bf49475478bcaa10",
+                "sha256:69cbbdf0631396e9925e048cfa5bce4e8c3d3b41562bbd70c685a8eb53a91e61",
+                "sha256:731c7022587006b755d0bdb27626a1a3bb004bb56b11fb30d98b6c1b4718579d",
+                "sha256:7be45519b830f7c24b21d630a31d48bcebfd5d4d7f9d3bdb49da9cdf6d764edb",
+                "sha256:898afce396b80fdda05e3086b4256f8677c671f7b1d27a6976fa011d3fd0a86e",
+                "sha256:8d58d8497814274d3d20214fbb24abcad2f7e351474357d552a8d53bce70c70e",
+                "sha256:9b0b14b49ac10654332a805aedfc0147fb3469cbf8ea951b3d040dab12372594",
+                "sha256:9d9f8bcb4c3be7738add259738abdeddc363de1b80e3310e04067aa1ca596634",
+                "sha256:a7a102574faa3f421141a64c10216e078df467ab9576684d5cd696952546e2da",
+                "sha256:a7f6524e3747e35f80744537c78e7302cd41deee8baa668d56d55f77d9c464b3",
+                "sha256:b6b27cf01e243871390474a211a7922bfbe3bda21e39bc9160daf0da3fe48876",
+                "sha256:b7ae0bbdc8c6674259b25bef5d2a1d6af5d39d7200c819cf99e07f7dfef1c51e",
+                "sha256:bd04ec08f7f8bd113c55868bd3fc442a9db67c27af098c5f814a3091e71cc61a",
+                "sha256:c077f48aab61738c237802836fc3844f85409a46015635198761b0d6a688f87b",
+                "sha256:cdc4c17afda4dab2a9c0b79148a43a7f4e1094916b3e18d8975bfd6d6d52241f",
+                "sha256:cf56ec8b0a5c8c9d7021d6fd754e688104f9ebebf1bf4449613c9531f5346a18",
+                "sha256:d2fe8e7f3ce329a71b7ddd7498b3cfac0eeb200c2789bd840234f0dc271a8efe",
+                "sha256:dc56bc708f2d8ac71bd1dcb927e458c93cec10b98eb4120206a4091db7b67b99",
+                "sha256:e563271e2c5ff4d4a4cbeb2c83d5cf0d4938b891518e676025f7268c6fe5fe26",
+                "sha256:e72a8ec6b868e258a2cd2672d91f2860ad532d590ce94cdf7d5e7ec674ccf03d",
+                "sha256:e99310a4ebd4479bcd1964dff9e14af33746300cb014aa4a3781738ac63baf4a",
+                "sha256:f522e5709379d72fb3da7785aa489ff0bb87448a9dc5a75f45763a795a089ebd",
+                "sha256:fc0d2f88b81dcf3ccf9a6ae17f89183762c8a94a5bdcfa09e05cfe413acf0503",
+                "sha256:fee33b0ca46f4c85443d6c450357101e47d53e6c3f008d658c27a2d020d44c79"
             ],
             "markers": "python_version >= '3.9'",
-            "version": "==20.0.0"
+            "version": "==21.0.0"
         },
         "python-dateutil": {
             "hashes": [
@@ -274,11 +262,11 @@
         },
         "s3transfer": {
             "hashes": [
-                "sha256:0148ef34d6dd964d0d8cf4311b2b21c474693e57c2e069ec708ce043d2b527be",
-                "sha256:f5e6db74eb7776a37208001113ea7aa97695368242b364d73e91c981ac522177"
+                "sha256:a981aa7429be23fe6dfc13e80e4020057cbab622b08c0315288758d67cabc724",
+                "sha256:c3fdba22ba1bd367922f27ec8032d6a1cf5f10c934fb5d68cf60fd5a23d936cf"
             ],
             "markers": "python_version >= '3.9'",
-            "version": "==0.13.0"
+            "version": "==0.13.1"
         },
         "six": {
             "hashes": [
@@ -290,16 +278,16 @@
         },
         "smart-open": {
             "hashes": [
-                "sha256:4b8489bb6058196258bafe901730c7db0dcf4f083f316e97269c66f45502055b",
-                "sha256:a4f09f84f0f6d3637c6543aca7b5487438877a21360e7368ccf1f704789752ba"
+                "sha256:c73661a2c24bf045c1e04e08fffc585b59af023fe783d57896f590489db66fb4",
+                "sha256:ce6a3d9bc1afbf6234ad13c010b77f8cd36d24636811e3c52c3b5160f5214d1e"
             ],
             "index": "pypi",
-            "markers": "python_version >= '3.7' and python_version < '4.0'",
-            "version": "==7.1.0"
+            "markers": "python_version >= '3.8' and python_version < '4.0'",
+            "version": "==7.3.0.post1"
         },
         "timdex-dataset-api": {
             "git": "https://github.com/MITLibraries/timdex-dataset-api.git",
-            "ref": "0a20234caa7615e94979be6841107d71ffc87b5b"
+            "ref": "9bf9b1becf57dc63a929fb382bbbed5c8e8f4d59"
         },
         "tzdata": {
             "hashes": [
@@ -450,38 +438,38 @@
         },
         "boto3": {
             "hashes": [
-                "sha256:0fe6b7d1974851588ec1edd39c66d9525d539133e02c7f985f9ebec5e222c0db",
-                "sha256:6f4163cd9e030afd1059e8a6daa178835165b79eb0b5325a8cd447020b895921"
+                "sha256:1a715cb40ea9df6b666148b243b5b9adbfa5be50d28e2f660330c0581d94b639",
+                "sha256:bbf7a8d374b513975c305883ae40e623cc261dbdc25ea86ae435647cae837a15"
             ],
             "markers": "python_version >= '3.9'",
-            "version": "==1.38.38"
+            "version": "==1.39.12"
         },
         "boto3-stubs": {
             "extras": [
                 "essential"
             ],
             "hashes": [
-                "sha256:4572065010391c5b3ff51129d0ac76f40b35b5ae6f5585bcb1d0454341e97f19",
-                "sha256:7b8ac61e65af3c987e53b438a9741f6de976c43137ec9d78c95067e8fda4df0c"
+                "sha256:53e51da27e5884fb35df1e0693a4e8127a26f7d4ba4ba0c9765b539d6b9c9924",
+                "sha256:cb0fbc36ce99834357612d4eb29383041cda3d08dec6bd6c8179e8b9a3f0fd6d"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==1.38.38"
+            "version": "==1.39.12"
         },
         "botocore": {
             "hashes": [
-                "sha256:aa5cc63bf885819d862852edb647d6276fe423c60113e8db375bb7ad8d88a5d9",
-                "sha256:acf9ae5b2d99c1f416f94fa5b4f8c044ecb76ffcb7fb1b1daec583f36892a8e2"
+                "sha256:60bfa0f1e0eb03997e22254e2e6a0e3f7e02b8f845253a4bb235d9240d195c72",
+                "sha256:d20b53a196af32ff153cbdbef3cb89e6a9065dc5e90ce23d009e03364601a266"
             ],
             "markers": "python_version >= '3.9'",
-            "version": "==1.38.38"
+            "version": "==1.39.12"
         },
         "botocore-stubs": {
             "hashes": [
-                "sha256:291d7bf39a316c00a8a55b7255489b02c0cea1a343482e7784e8d1e235bae995",
-                "sha256:2efb8bdf36504aff596c670d875d8f7dd15205277c15c4cea54afdba8200c266"
+                "sha256:a04e69766ab8bae338911c1897492f88d05cd489cd75f06e6eb4f135f9da8c7b",
+                "sha256:cc21d9a7dd994bdd90872db4664d817c4719b51cda8004fd507a4bf65b085a75"
             ],
-            "markers": "python_version >= '3.8'",
-            "version": "==1.38.30"
+            "markers": "python_version >= '3.9'",
+            "version": "==1.38.46"
         },
         "cachecontrol": {
             "extras": [
@@ -496,11 +484,11 @@
         },
         "certifi": {
             "hashes": [
-                "sha256:2e0c7ce7cb5d8f8634ca55d2ba7e6ec2689a2fd6537d8dec1296a477a4910057",
-                "sha256:d747aa5a8b9bbbb1bb8c22bb13e22bd1f18e9796defa16bab421f7f7a317323b"
+                "sha256:6b31f564a415d79ee77df69d757bb49a5bb53bd9f756cbbe24394ffd6fc1f4b2",
+                "sha256:8ea99dbdfaaf2ba2f9bac77b9249ef62ec5218e7c2b2e903378ed5fccf765995"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==2025.6.15"
+            "version": "==2025.7.14"
         },
         "cffi": {
             "hashes": [
@@ -691,120 +679,120 @@
         },
         "coverage": {
             "hashes": [
-                "sha256:02532fd3290bb8fa6bec876520842428e2a6ed6c27014eca81b031c2d30e3f71",
-                "sha256:0a4be2a28656afe279b34d4f91c3e26eccf2f85500d4a4ff0b1f8b54bf807338",
-                "sha256:0b3496922cb5f4215bf5caaef4cf12364a26b0be82e9ed6d050f3352cf2d7ef0",
-                "sha256:0c804506d624e8a20fb3108764c52e0eef664e29d21692afa375e0dd98dc384f",
-                "sha256:0f16649a7330ec307942ed27d06ee7e7a38417144620bb3d6e9a18ded8a2d3e5",
-                "sha256:16aa0830d0c08a2c40c264cef801db8bc4fc0e1892782e45bcacbd5889270509",
-                "sha256:18a0912944d70aaf5f399e350445738a1a20b50fbea788f640751c2ed9208b6c",
-                "sha256:1c503289ffef1d5105d91bbb4d62cbe4b14bec4d13ca225f9c73cde9bb46207d",
-                "sha256:2241ad5dbf79ae1d9c08fe52b36d03ca122fb9ac6bca0f34439e99f8327ac89f",
-                "sha256:25308bd3d00d5eedd5ae7d4357161f4df743e3c0240fa773ee1b0f75e6c7c0f1",
-                "sha256:2a876e4c3e5a2a1715a6608906aa5a2e0475b9c0f68343c2ada98110512ab1d8",
-                "sha256:2d04b16a6062516df97969f1ae7efd0de9c31eb6ebdceaa0d213b21c0ca1a683",
-                "sha256:30f445f85c353090b83e552dcbbdad3ec84c7967e108c3ae54556ca69955563e",
-                "sha256:31324f18d5969feef7344a932c32428a2d1a3e50b15a6404e97cba1cc9b2c631",
-                "sha256:34ed2186fe52fcc24d4561041979a0dec69adae7bce2ae8d1c49eace13e55c43",
-                "sha256:37ab6be0859141b53aa89412a82454b482c81cf750de4f29223d52268a86de67",
-                "sha256:37ae0383f13cbdcf1e5e7014489b0d71cc0106458878ccde52e8a12ced4298ed",
-                "sha256:382e7ddd5289f140259b610e5f5c58f713d025cb2f66d0eb17e68d0a94278875",
-                "sha256:3bb5838701ca68b10ebc0937dbd0eb81974bac54447c55cd58dea5bca8451029",
-                "sha256:437c576979e4db840539674e68c84b3cda82bc824dd138d56bead1435f1cb5d7",
-                "sha256:49f1d0788ba5b7ba65933f3a18864117c6506619f5ca80326b478f72acf3f385",
-                "sha256:52e92b01041151bf607ee858e5a56c62d4b70f4dac85b8c8cb7fb8a351ab2c10",
-                "sha256:535fde4001b2783ac80865d90e7cc7798b6b126f4cd8a8c54acfe76804e54e58",
-                "sha256:56f5eb308b17bca3bbff810f55ee26d51926d9f89ba92707ee41d3c061257e55",
-                "sha256:5add197315a054e92cee1b5f686a2bcba60c4c3e66ee3de77ace6c867bdee7cb",
-                "sha256:5f646a99a8c2b3ff4c6a6e081f78fad0dde275cd59f8f49dc4eab2e394332e74",
-                "sha256:600a1d4106fe66f41e5d0136dfbc68fe7200a5cbe85610ddf094f8f22e1b0300",
-                "sha256:60c458224331ee3f1a5b472773e4a085cc27a86a0b48205409d364272d67140d",
-                "sha256:64bdd969456e2d02a8b08aa047a92d269c7ac1f47e0c977675d550c9a0863643",
-                "sha256:66b974b145aa189516b6bf2d8423e888b742517d37872f6ee4c5be0073bd9a3c",
-                "sha256:684e2110ed84fd1ca5f40e89aa44adf1729dc85444004111aa01866507adf363",
-                "sha256:68cd53aec6f45b8e4724c0950ce86eacb775c6be01ce6e3669fe4f3a21e768ed",
-                "sha256:69aa417a030bf11ec46149636314c24c8d60fadb12fc0ee8f10fda0d918c879d",
-                "sha256:6ad935f0016be24c0e97fc8c40c465f9c4b85cbbe6eac48934c0dc4d2568321e",
-                "sha256:6b55ad10a35a21b8015eabddc9ba31eb590f54adc9cd39bcf09ff5349fd52125",
-                "sha256:6cf43c78c4282708a28e466316935ec7489a9c487518a77fa68f716c67909cec",
-                "sha256:6f424507f57878e424d9a95dc4ead3fbdd72fd201e404e861e465f28ea469951",
-                "sha256:70760b4c5560be6ca70d11f8988ee6542b003f982b32f83d5ac0b72476607b70",
-                "sha256:73e9439310f65d55a5a1e0564b48e34f5369bee943d72c88378f2d576f5a5751",
-                "sha256:7931b9e249edefb07cd6ae10c702788546341d5fe44db5b6108a25da4dca513f",
-                "sha256:81f34346dd63010453922c8e628a52ea2d2ccd73cb2487f7700ac531b247c8a5",
-                "sha256:888f8eee13f2377ce86d44f338968eedec3291876b0b8a7289247ba52cb984cd",
-                "sha256:95335095b6c7b1cc14c3f3f17d5452ce677e8490d101698562b2ffcacc304c8d",
-                "sha256:9565c3ab1c93310569ec0d86b017f128f027cab0b622b7af288696d7ed43a16d",
-                "sha256:95c765060e65c692da2d2f51a9499c5e9f5cf5453aeaf1420e3fc847cc060582",
-                "sha256:9969ef1e69b8c8e1e70d591f91bbc37fc9a3621e447525d1602801a24ceda898",
-                "sha256:9ca8e220006966b4a7b68e8984a6aee645a0384b0769e829ba60281fe61ec4f7",
-                "sha256:a39d18b3f50cc121d0ce3838d32d58bd1d15dab89c910358ebefc3665712256c",
-                "sha256:a66e8f628b71f78c0e0342003d53b53101ba4e00ea8dabb799d9dba0abbbcebe",
-                "sha256:a8de12b4b87c20de895f10567639c0797b621b22897b0af3ce4b4e204a743626",
-                "sha256:af41da5dca398d3474129c58cb2b106a5d93bbb196be0d307ac82311ca234342",
-                "sha256:b30a25f814591a8c0c5372c11ac8967f669b97444c47fd794926e175c4047ece",
-                "sha256:ba383dc6afd5ec5b7a0d0c23d38895db0e15bcba7fb0fa8901f245267ac30d86",
-                "sha256:bb4fbcab8764dc072cb651a4bcda4d11fb5658a1d8d68842a862a6610bd8cfa3",
-                "sha256:be9e3f68ca9edb897c2184ad0eee815c635565dbe7a0e7e814dc1f7cbab92c0a",
-                "sha256:bfa447506c1a52271f1b0de3f42ea0fa14676052549095e378d5bff1c505ff7b",
-                "sha256:cc94d7c5e8423920787c33d811c0be67b7be83c705f001f7180c7b186dcf10ca",
-                "sha256:cea0a27a89e6432705fffc178064503508e3c0184b4f061700e771a09de58187",
-                "sha256:cf95981b126f23db63e9dbe4cf65bd71f9a6305696fa5e2262693bc4e2183f5b",
-                "sha256:d4fe2348cc6ec372e25adec0219ee2334a68d2f5222e0cba9c0d613394e12d86",
-                "sha256:db0f04118d1db74db6c9e1cb1898532c7dcc220f1d2718f058601f7c3f499514",
-                "sha256:dd24bd8d77c98557880def750782df77ab2b6885a18483dc8588792247174b32",
-                "sha256:e1b5191d1648acc439b24721caab2fd0c86679d8549ed2c84d5a7ec1bedcc244",
-                "sha256:e5532482344186c543c37bfad0ee6069e8ae4fc38d073b8bc836fc8f03c9e250",
-                "sha256:e980b53a959fa53b6f05343afbd1e6f44a23ed6c23c4b4c56c6662bbb40c82ce",
-                "sha256:ef64c27bc40189f36fcc50c3fb8f16ccda73b6a0b80d9bd6e6ce4cffcd810bbd",
-                "sha256:f05031cf21699785cd47cb7485f67df619e7bcdae38e0fde40d23d3d0210d3c3"
+                "sha256:0a07757de9feb1dfafd16ab651e0f628fd7ce551604d1bf23e47e1ddca93f08a",
+                "sha256:0a17eaf46f56ae0f870f14a3cbc2e4632fe3771eab7f687eda1ee59b73d09fe4",
+                "sha256:0b4a4cb73b9f2b891c1788711408ef9707666501ba23684387277ededab1097c",
+                "sha256:0c0378ba787681ab1897f7c89b415bd56b0b2d9a47e5a3d8dc0ea55aac118d6c",
+                "sha256:115db3d1f4d3f35f5bb021e270edd85011934ff97c8797216b62f461dd69374b",
+                "sha256:123d589f32c11d9be7fe2e66d823a236fe759b0096f5db3fb1b75b2fa414a4fa",
+                "sha256:14fa8d3da147f5fdf9d298cacc18791818f3f1a9f542c8958b80c228320e90c6",
+                "sha256:19e7be4cfec248df38ce40968c95d3952fbffd57b400d4b9bb580f28179556d2",
+                "sha256:1df6b76e737c6a92210eebcb2390af59a141f9e9430210595251fbaf02d46926",
+                "sha256:1e2f097eae0e5991e7623958a24ced3282676c93c013dde41399ff63e230fcf2",
+                "sha256:256ea87cb2a1ed992bcdfc349d8042dcea1b80436f4ddf6e246d6bee4b5d73b6",
+                "sha256:28dc1f67e83a14e7079b6cea4d314bc8b24d1aed42d3582ff89c0295f09b181e",
+                "sha256:2c8937fa16c8c9fbbd9f118588756e7bcdc7e16a470766a9aef912dd3f117dbd",
+                "sha256:2d0d4f6ecdf37fcc19c88fec3e2277d5dee740fb51ffdd69b9579b8c31e4232e",
+                "sha256:2f3da12e0ccbcb348969221d29441ac714bbddc4d74e13923d3d5a7a0bebef7a",
+                "sha256:31991156251ec202c798501e0a42bbdf2169dcb0f137b1f5c0f4267f3fc68ef9",
+                "sha256:326802760da234baf9f2f85a39e4a4b5861b94f6c8d95251f699e4f73b1835dc",
+                "sha256:333b2e0ca576a7dbd66e85ab402e35c03b0b22f525eed82681c4b866e2e2653a",
+                "sha256:42da2280c4d30c57a9b578bafd1d4494fa6c056d4c419d9689e66d775539be74",
+                "sha256:48f82f889c80af8b2a7bb6e158d95a3fbec6a3453a1004d04e4f3b5945a02694",
+                "sha256:49b752a2858b10580969ec6af6f090a9a440a64a301ac1528d7ca5f7ed497f4d",
+                "sha256:4b1c2d8363247b46bd51f393f86c94096e64a1cf6906803fa8d5a9d03784bdbf",
+                "sha256:4e01d138540ef34fcf35c1aa24d06c3de2a4cffa349e29a10056544f35cca15f",
+                "sha256:4e2c058aef613e79df00e86b6d42a641c877211384ce5bd07585ed7ba71ab31b",
+                "sha256:549cab4892fc82004f9739963163fd3aac7a7b0df430669b75b86d293d2df2a7",
+                "sha256:55a28954545f9d2f96870b40f6c3386a59ba8ed50caf2d949676dac3ecab99f5",
+                "sha256:619317bb86de4193debc712b9e59d5cffd91dc1d178627ab2a77b9870deb2868",
+                "sha256:6406cff19880aaaadc932152242523e892faff224da29e241ce2fca329866584",
+                "sha256:66283a192a14a3854b2e7f3418d7db05cdf411012ab7ff5db98ff3b181e1f912",
+                "sha256:669135a9d25df55d1ed56a11bf555f37c922cf08d80799d4f65d77d7d6123fcf",
+                "sha256:71ae8b53855644a0b1579d4041304ddc9995c7b21c8a1f16753c4d8903b4dfed",
+                "sha256:82c3939264a76d44fde7f213924021ed31f55ef28111a19649fec90c0f109e6d",
+                "sha256:82d76ad87c932935417a19b10cfe7abb15fd3f923cfe47dbdaa74ef4e503752d",
+                "sha256:88d7598b8ee130f32f8a43198ee02edd16d7f77692fa056cb779616bbea1b355",
+                "sha256:8a1166db2fb62473285bcb092f586e081e92656c7dfa8e9f62b4d39d7e6b5050",
+                "sha256:9303aed20872d7a3c9cb39c5d2b9bdbe44e3a9a1aecb52920f7e7495410dfab8",
+                "sha256:985abe7f242e0d7bba228ab01070fde1d6c8fa12f142e43debe9ed1dde686038",
+                "sha256:997024fa51e3290264ffd7492ec97d0690293ccd2b45a6cd7d82d945a4a80c8b",
+                "sha256:9ce85551f9a1119f02adc46d3014b5ee3f765deac166acf20dbb851ceb79b6f3",
+                "sha256:9d3a700304d01a627df9db4322dc082a0ce1e8fc74ac238e2af39ced4c083193",
+                "sha256:9dfb070f830739ee49d7c83e4941cc767e503e4394fdecb3b54bfdac1d7662c0",
+                "sha256:a535c0c7364acd55229749c2b3e5eebf141865de3a8f697076a3291985f02d30",
+                "sha256:a7a56a2964a9687b6aba5b5ced6971af308ef6f79a91043c05dd4ee3ebc3e9ba",
+                "sha256:ae5d563e970dbe04382f736ec214ef48103d1b875967c89d83c6e3f21706d5b3",
+                "sha256:ae9eb07f1cfacd9cfe8eaee6f4ff4b8a289a668c39c165cd0c8548484920ffc0",
+                "sha256:bc18ea9e417a04d1920a9a76fe9ebd2f43ca505b81994598482f938d5c315f46",
+                "sha256:bcd5ebe66c7a97273d5d2ddd4ad0ed2e706b39630ed4b53e713d360626c3dbb3",
+                "sha256:bdd612e59baed2a93c8843c9a7cb902260f181370f1d772f4842987535071d14",
+                "sha256:bf7d773da6af9e10dbddacbf4e5cab13d06d0ed93561d44dae0188a42c65be7e",
+                "sha256:c10c882b114faf82dbd33e876d0cbd5e1d1ebc0d2a74ceef642c6152f3f4d547",
+                "sha256:c2667a2b913e307f06aa4e5677f01a9746cd08e4b35e14ebcde6420a9ebb4c62",
+                "sha256:c33624f50cf8de418ab2b4d6ca9eda96dc45b2c4231336bac91454520e8d1fac",
+                "sha256:c48c2375287108c887ee87d13b4070a381c6537d30e8487b24ec721bf2a781cb",
+                "sha256:cdef6504637731a63c133bb2e6f0f0214e2748495ec15fe42d1e219d1b133f0b",
+                "sha256:d0d67963f9cbfc7c7f96d4ac74ed60ecbebd2ea6eeb51887af0f8dce205e545f",
+                "sha256:dd7a57b33b5cf27acb491e890720af45db05589a80c1ffc798462a765be6d4d7",
+                "sha256:ddc39510ac922a5c4c27849b739f875d3e1d9e590d1e7b64c98dadf037a16cce",
+                "sha256:de3c0378bdf7066c3988d66cd5232d161e933b87103b014ab1b0b4676098fa45",
+                "sha256:df0f9ef28e0f20c767ccdccfc5ae5f83a6f4a2fbdfbcbcc8487a8a78771168c8",
+                "sha256:e425cd5b00f6fc0ed7cdbd766c70be8baab4b7839e4d4fe5fac48581dd968ea4",
+                "sha256:f22627c1fe2745ee98d3ab87679ca73a97e75ca75eb5faee48660d060875465f",
+                "sha256:f44ae036b63c8ea432f610534a2668b0c3aee810e7037ab9d8ff6883de480f5b",
+                "sha256:f5fd54310b92741ebe00d9c0d1d7b2b27463952c022da6d47c175d246a98d1bd",
+                "sha256:f65bb452e579d5540c8b37ec105dd54d8b9307b07bcaa186818c104ffda22441",
+                "sha256:f8f6389ac977c5fb322e0e38885fbbf901743f79d47f50db706e7644dcdcb6e1",
+                "sha256:fae939811e14e53ed8a9818dad51d434a41ee09df9305663735f2e2d2d7d959b",
+                "sha256:ff0d9eae8cdfcd58fe7893b88993723583a6ce4dfbfd9f29e001922544f95615"
             ],
             "index": "pypi",
             "markers": "python_version >= '3.9'",
-            "version": "==7.9.1"
+            "version": "==7.9.2"
         },
         "cryptography": {
             "hashes": [
-                "sha256:0339a692de47084969500ee455e42c58e449461e0ec845a34a6a9b9bf7df7fb8",
-                "sha256:03dbff8411206713185b8cebe31bc5c0eb544799a50c09035733716b386e61a4",
-                "sha256:06509dc70dd71fa56eaa138336244e2fbaf2ac164fc9b5e66828fccfd2b680d6",
-                "sha256:0cf13c77d710131d33e63626bd55ae7c0efb701ebdc2b3a7952b9b23a0412862",
-                "sha256:23b9c3ea30c3ed4db59e7b9619272e94891f8a3a5591d0b656a7582631ccf750",
-                "sha256:25eb4d4d3e54595dc8adebc6bbd5623588991d86591a78c2548ffb64797341e2",
-                "sha256:2882338b2a6e0bd337052e8b9007ced85c637da19ef9ecaf437744495c8c2999",
-                "sha256:3530382a43a0e524bc931f187fc69ef4c42828cf7d7f592f7f249f602b5a4ab0",
-                "sha256:425a9a6ac2823ee6e46a76a21a4e8342d8fa5c01e08b823c1f19a8b74f096069",
-                "sha256:46cf7088bf91bdc9b26f9c55636492c1cce3e7aaf8041bbf0243f5e5325cfb2d",
-                "sha256:4828190fb6c4bcb6ebc6331f01fe66ae838bb3bd58e753b59d4b22eb444b996c",
-                "sha256:49fe9155ab32721b9122975e168a6760d8ce4cffe423bcd7ca269ba41b5dfac1",
-                "sha256:4ca0f52170e821bc8da6fc0cc565b7bb8ff8d90d36b5e9fdd68e8a86bdf72036",
-                "sha256:51dfbd4d26172d31150d84c19bbe06c68ea4b7f11bbc7b3a5e146b367c311349",
-                "sha256:5f31e6b0a5a253f6aa49be67279be4a7e5a4ef259a9f33c69f7d1b1191939872",
-                "sha256:627ba1bc94f6adf0b0a2e35d87020285ead22d9f648c7e75bb64f367375f3b22",
-                "sha256:680806cf63baa0039b920f4976f5f31b10e772de42f16310a6839d9f21a26b0d",
-                "sha256:6a3511ae33f09094185d111160fd192c67aa0a2a8d19b54d36e4c78f651dc5ad",
-                "sha256:6a5bf57554e80f75a7db3d4b1dacaa2764611ae166ab42ea9a72bcdb5d577637",
-                "sha256:6b613164cb8425e2f8db5849ffb84892e523bf6d26deb8f9bb76ae86181fa12b",
-                "sha256:7405ade85c83c37682c8fe65554759800a4a8c54b2d96e0f8ad114d31b808d57",
-                "sha256:7aad98a25ed8ac917fdd8a9c1e706e5a0956e06c498be1f713b61734333a4507",
-                "sha256:7bedbe4cc930fa4b100fc845ea1ea5788fcd7ae9562e669989c11618ae8d76ee",
-                "sha256:7ef2dde4fa9408475038fc9aadfc1fb2676b174e68356359632e980c661ec8f6",
-                "sha256:817ee05c6c9f7a69a16200f0c90ab26d23a87701e2a284bd15156783e46dbcc8",
-                "sha256:944e9ccf67a9594137f942d5b52c8d238b1b4e46c7a0c2891b7ae6e01e7c80a4",
-                "sha256:964bcc28d867e0f5491a564b7debb3ffdd8717928d315d12e0d7defa9e43b723",
-                "sha256:96d4819e25bf3b685199b304a0029ce4a3caf98947ce8a066c9137cc78ad2c58",
-                "sha256:a77c6fb8d76e9c9f99f2f3437c1a4ac287b34eaf40997cfab1e9bd2be175ac39",
-                "sha256:b0a97c927497e3bc36b33987abb99bf17a9a175a19af38a892dc4bbb844d7ee2",
-                "sha256:b97737a3ffbea79eebb062eb0d67d72307195035332501722a9ca86bab9e3ab2",
-                "sha256:bbc505d1dc469ac12a0a064214879eac6294038d6b24ae9f71faae1448a9608d",
-                "sha256:c22fe01e53dc65edd1945a2e6f0015e887f84ced233acecb64b4daadb32f5c97",
-                "sha256:ce1678a2ccbe696cf3af15a75bb72ee008d7ff183c9228592ede9db467e64f1b",
-                "sha256:e00a6c10a5c53979d6242f123c0a97cff9f3abed7f064fc412c36dc521b5f257",
-                "sha256:eaa3e28ea2235b33220b949c5a0d6cf79baa80eab2eb5607ca8ab7525331b9ff",
-                "sha256:f3fe7a5ae34d5a414957cc7f457e2b92076e72938423ac64d215722f6cf49a9e"
+                "sha256:0027d566d65a38497bc37e0dd7c2f8ceda73597d2ac9ba93810204f56f52ebc7",
+                "sha256:101ee65078f6dd3e5a028d4f19c07ffa4dd22cce6a20eaa160f8b5219911e7d8",
+                "sha256:12e55281d993a793b0e883066f590c1ae1e802e3acb67f8b442e721e475e6463",
+                "sha256:14d96584701a887763384f3c47f0ca7c1cce322aa1c31172680eb596b890ec30",
+                "sha256:1e1da5accc0c750056c556a93c3e9cb828970206c68867712ca5805e46dc806f",
+                "sha256:206210d03c1193f4e1ff681d22885181d47efa1ab3018766a7b32a7b3d6e6afd",
+                "sha256:2089cc8f70a6e454601525e5bf2779e665d7865af002a5dec8d14e561002e135",
+                "sha256:3a264aae5f7fbb089dbc01e0242d3b67dffe3e6292e1f5182122bdf58e65215d",
+                "sha256:3af26738f2db354aafe492fb3869e955b12b2ef2e16908c8b9cb928128d42c57",
+                "sha256:3fcfbefc4a7f332dece7272a88e410f611e79458fab97b5efe14e54fe476f4fd",
+                "sha256:460f8c39ba66af7db0545a8c6f2eabcbc5a5528fc1cf6c3fa9a1e44cec33385e",
+                "sha256:57c816dfbd1659a367831baca4b775b2a5b43c003daf52e9d57e1d30bc2e1b0e",
+                "sha256:5aa1e32983d4443e310f726ee4b071ab7569f58eedfdd65e9675484a4eb67bd1",
+                "sha256:6ff8728d8d890b3dda5765276d1bc6fb099252915a2cd3aff960c4c195745dd0",
+                "sha256:7259038202a47fdecee7e62e0fd0b0738b6daa335354396c6ddebdbe1206af2a",
+                "sha256:72e76caa004ab63accdf26023fccd1d087f6d90ec6048ff33ad0445abf7f605a",
+                "sha256:7760c1c2e1a7084153a0f68fab76e754083b126a47d0117c9ed15e69e2103492",
+                "sha256:8c4a6ff8a30e9e3d38ac0539e9a9e02540ab3f827a3394f8852432f6b0ea152e",
+                "sha256:9024beb59aca9d31d36fcdc1604dd9bbeed0a55bface9f1908df19178e2f116e",
+                "sha256:90cb0a7bb35959f37e23303b7eed0a32280510030daba3f7fdfbb65defde6a97",
+                "sha256:91098f02ca81579c85f66df8a588c78f331ca19089763d733e34ad359f474174",
+                "sha256:926c3ea71a6043921050eaa639137e13dbe7b4ab25800932a8498364fc1abec9",
+                "sha256:982518cd64c54fcada9d7e5cf28eabd3ee76bd03ab18e08a48cad7e8b6f31b18",
+                "sha256:9b4cf6318915dccfe218e69bbec417fdd7c7185aa7aab139a2c0beb7468c89f0",
+                "sha256:ad0caded895a00261a5b4aa9af828baede54638754b51955a0ac75576b831b27",
+                "sha256:b85980d1e345fe769cfc57c57db2b59cff5464ee0c045d52c0df087e926fbe63",
+                "sha256:b8fa8b0a35a9982a3c60ec79905ba5bb090fc0b9addcfd3dc2dd04267e45f25e",
+                "sha256:b9e38e0a83cd51e07f5a48ff9691cae95a79bea28fe4ded168a8e5c6c77e819d",
+                "sha256:bd4c45986472694e5121084c6ebbd112aa919a25e783b87eb95953c9573906d6",
+                "sha256:be97d3a19c16a9be00edf79dca949c8fa7eff621763666a145f9f9535a5d7f42",
+                "sha256:c648025b6840fe62e57107e0a25f604db740e728bd67da4f6f060f03017d5097",
+                "sha256:d05a38884db2ba215218745f0781775806bde4f32e07b135348355fe8e4991d9",
+                "sha256:dd420e577921c8c2d31289536c386aaa30140b473835e97f83bc71ea9d2baf2d",
+                "sha256:e357286c1b76403dd384d938f93c46b2b058ed4dfcdce64a770f0537ed3feb6f",
+                "sha256:e6c00130ed423201c5bc5544c23359141660b07999ad82e34e7bb8f882bb78e0",
+                "sha256:e74d30ec9c7cb2f404af331d5b4099a9b322a8a6b25c4632755c8757345baac5",
+                "sha256:f3562c2f23c612f2e4a6964a61d942f891d29ee320edb62ff48ffb99f3de9ae8"
             ],
             "markers": "python_version >= '3.7' and python_full_version not in '3.9.0, 3.9.1'",
-            "version": "==45.0.4"
+            "version": "==45.0.5"
         },
         "cyclonedx-python-lib": {
             "hashes": [
@@ -832,10 +820,10 @@
         },
         "distlib": {
             "hashes": [
-                "sha256:47f8c22fd27c27e25a65601af709b38e4f0a45ea4fc2e710f65755fa8caaaf87",
-                "sha256:a60f20dea646b8a33f3e7772f74dc0b2d0772d2837ee1342a00645c81edf9403"
+                "sha256:9659f7d87e46584a30b5780e43ac7a2143098441670ff0a49d5f9034c54a6c16",
+                "sha256:feec40075be03a04501a973d81f633735b4b69f98b05450592310c0f401a4e0d"
             ],
-            "version": "==0.3.9"
+            "version": "==0.4.0"
         },
         "executing": {
             "hashes": [
@@ -855,12 +843,12 @@
         },
         "freezegun": {
             "hashes": [
-                "sha256:5aaf3ba229cda57afab5bd311f0108d86b6fb119ae89d2cd9c43ec8c1733c85b",
-                "sha256:a54ae1d2f9c02dbf42e02c18a3ab95ab4295818b549a34dac55592d72a905181"
+                "sha256:1ce20ee4be61349ba52c3af64f5eaba8d08ff51acfcf1b3ea671f03e54c818f1",
+                "sha256:d7c6204e33a50affd7c7aa284f4f92e04e96f72d63313b89ceaaf60d9c64bc5e"
             ],
             "index": "pypi",
             "markers": "python_version >= '3.8'",
-            "version": "==1.5.2"
+            "version": "==1.5.3"
         },
         "identify": {
             "hashes": [
@@ -888,12 +876,12 @@
         },
         "ipython": {
             "hashes": [
-                "sha256:1a0b6dd9221a1f5dddf725b57ac0cb6fddc7b5f470576231ae9162b9b3455a04",
-                "sha256:79eb896f9f23f50ad16c3bc205f686f6e030ad246cc309c6279a242b14afe9d8"
+                "sha256:25850f025a446d9b359e8d296ba175a36aedd32e83ca9b5060430fe16801f066",
+                "sha256:c033c6d4e7914c3d9768aabe76bbe87ba1dc66a92a05db6bfa1125d81f2ee270"
             ],
             "index": "pypi",
             "markers": "python_version >= '3.11'",
-            "version": "==9.3.0"
+            "version": "==9.4.0"
         },
         "ipython-pygments-lexers": {
             "hashes": [
@@ -929,11 +917,11 @@
         },
         "license-expression": {
             "hashes": [
-                "sha256:679646bc3261a17690494a3e1cada446e5ee342dbd87dcfa4a0c24cc5dce13ee",
-                "sha256:9f02105f9e0fcecba6a85dfbbed7d94ea1c3a70cf23ddbfb5adf3438a6f6fce0"
+                "sha256:421788fdcadb41f049d2dc934ce666626265aeccefddd25e162a26f23bcbf8a4",
+                "sha256:73448f0aacd8d0808895bdc4b2c8e01a8d67646e4188f887375398c761f340fd"
             ],
             "markers": "python_version >= '3.9'",
-            "version": "==30.4.1"
+            "version": "==30.4.4"
         },
         "markdown-it-py": {
             "hashes": [
@@ -1028,12 +1016,12 @@
         },
         "moto": {
             "hashes": [
-                "sha256:baf7afa9d4a92f07277b29cf466d0738f25db2ed2ee12afcb1dc3f2c540beebd",
-                "sha256:e4a3092bc8fe9139caa77cd34cdcbad804de4d9671e2270ea3b4d53f5c645047"
+                "sha256:12f3a15100da7de019c671a516dbba33b14072faba103f16ca79a39b8c803b7d",
+                "sha256:5c2f63c051b7c13224cb1483917c85a796468d7e37dcd5d1a5b8de66729de3f4"
             ],
             "index": "pypi",
             "markers": "python_version >= '3.9'",
-            "version": "==5.1.6"
+            "version": "==5.1.8"
         },
         "msgpack": {
             "hashes": [
@@ -1102,98 +1090,98 @@
         },
         "mypy": {
             "hashes": [
-                "sha256:051e1677689c9d9578b9c7f4d206d763f9bbd95723cd1416fad50db49d52f359",
-                "sha256:08e850ea22adc4d8a4014651575567b0318ede51e8e9fe7a68f25391af699507",
-                "sha256:09aa4f91ada245f0a45dbc47e548fd94e0dd5a8433e0114917dc3b526912a30c",
-                "sha256:0a7cfb0fe29fe5a9841b7c8ee6dffb52382c45acdf68f032145b75620acfbd6f",
-                "sha256:0ab5eca37b50188163fa7c1b73c685ac66c4e9bdee4a85c9adac0e91d8895e15",
-                "sha256:1256688e284632382f8f3b9e2123df7d279f603c561f099758e66dd6ed4e8bd6",
-                "sha256:13c7cd5b1cb2909aa318a90fd1b7e31f17c50b242953e7dd58345b2a814f6383",
-                "sha256:1f0435cf920e287ff68af3d10a118a73f212deb2ce087619eb4e648116d1fe9b",
-                "sha256:211287e98e05352a2e1d4e8759c5490925a7c784ddc84207f4714822f8cf99b6",
-                "sha256:22d76a63a42619bfb90122889b903519149879ddbf2ba4251834727944c8baca",
-                "sha256:2c7ce0662b6b9dc8f4ed86eb7a5d505ee3298c04b40ec13b30e572c0e5ae17c4",
-                "sha256:352025753ef6a83cb9e7f2427319bb7875d1fdda8439d1e23de12ab164179574",
-                "sha256:44e7acddb3c48bd2713994d098729494117803616e116032af192871aed80b79",
-                "sha256:472e4e4c100062488ec643f6162dd0d5208e33e2f34544e1fc931372e806c0cc",
-                "sha256:4f58ac32771341e38a853c5d0ec0dfe27e18e27da9cdb8bbc882d2249c71a3ee",
-                "sha256:58e07fb958bc5d752a280da0e890c538f1515b79a65757bbdc54252ba82e0b40",
-                "sha256:5e198ab3f55924c03ead626ff424cad1732d0d391478dfbf7bb97b34602395da",
-                "sha256:5fc2ac4027d0ef28d6ba69a0343737a23c4d1b83672bf38d1fe237bdc0643b37",
-                "sha256:66df38405fd8466ce3517eda1f6640611a0b8e70895e2a9462d1d4323c5eb4b9",
-                "sha256:6bd00a0a2094841c5e47e7374bb42b83d64c527a502e3334e1173a0c24437bab",
-                "sha256:7fc688329af6a287567f45cc1cefb9db662defeb14625213a5b7da6e692e2069",
-                "sha256:86042bbf9f5a05ea000d3203cf87aa9d0ccf9a01f73f71c58979eb9249f46d72",
-                "sha256:87ff2c13d58bdc4bbe7dc0dedfe622c0f04e2cb2a492269f3b418df2de05c536",
-                "sha256:af4792433f09575d9eeca5c63d7d90ca4aeceda9d8355e136f80f8967639183d",
-                "sha256:b4f0fed1022a63c6fec38f28b7fc77fca47fd490445c69d0a66266c59dd0b88a",
-                "sha256:d5d2309511cc56c021b4b4e462907c2b12f669b2dbeb68300110ec27723971be",
-                "sha256:ddc91eb318c8751c69ddb200a5937f1232ee8efb4e64e9f4bc475a33719de438",
-                "sha256:dedb6229b2c9086247e21a83c309754b9058b438704ad2f6807f0d8227f6ebdd",
-                "sha256:ea16e2a7d2714277e349e24d19a782a663a34ed60864006e8585db08f8ad1782",
-                "sha256:ea7469ee5902c95542bea7ee545f7006508c65c8c54b06dc2c92676ce526f3ea",
-                "sha256:f895078594d918f93337a505f8add9bd654d1a24962b4c6ed9390e12531eb31b",
-                "sha256:ff9fa5b16e4c1364eb89a4d16bcda9987f05d39604e1e6c35378a2987c1aac2d"
+                "sha256:037bc0f0b124ce46bfde955c647f3e395c6174476a968c0f22c95a8d2f589bba",
+                "sha256:03ba330b76710f83d6ac500053f7727270b6b8553b0423348ffb3af6f2f7b889",
+                "sha256:0e69db1fb65b3114f98c753e3930a00514f5b68794ba80590eb02090d54a5d4a",
+                "sha256:1051df7ec0886fa246a530ae917c473491e9a0ba6938cfd0ec2abc1076495c3e",
+                "sha256:15d9d0018237ab058e5de3d8fce61b6fa72cc59cc78fd91f1b474bce12abf496",
+                "sha256:1619a485fd0e9c959b943c7b519ed26b712de3002d7de43154a489a2d0fd817d",
+                "sha256:24cfcc1179c4447854e9e406d3af0f77736d631ec87d31c6281ecd5025df625d",
+                "sha256:2c41aa59211e49d717d92b3bb1238c06d387c9325d3122085113c79118bebb06",
+                "sha256:3204d773bab5ff4ebbd1f8efa11b498027cd57017c003ae970f310e5b96be8d8",
+                "sha256:3c56f180ff6430e6373db7a1d569317675b0a451caf5fef6ce4ab365f5f2f6c3",
+                "sha256:434ad499ad8dde8b2f6391ddfa982f41cb07ccda8e3c67781b1bfd4e5f9450a8",
+                "sha256:51e455a54d199dd6e931cd7ea987d061c2afbaf0960f7f66deef47c90d1b304d",
+                "sha256:63e751f1b5ab51d6f3d219fe3a2fe4523eaa387d854ad06906c63883fde5b1ab",
+                "sha256:6ff25d151cc057fdddb1cb1881ef36e9c41fa2a5e78d8dd71bee6e4dcd2bc05b",
+                "sha256:73a0ff2dd10337ceb521c080d4147755ee302dcde6e1a913babd59473904615f",
+                "sha256:93468cf29aa9a132bceb103bd8475f78cacde2b1b9a94fd978d50d4bdf616c9a",
+                "sha256:98189382b310f16343151f65dd7e6867386d3e35f7878c45cfa11383d175d91f",
+                "sha256:9d4fe5c72fd262d9c2c91c1117d16aac555e05f5beb2bae6a755274c6eec42be",
+                "sha256:b72c34ce05ac3a1361ae2ebb50757fb6e3624032d91488d93544e9f82db0ed6c",
+                "sha256:ba06254a5a22729853209550d80f94e28690d5530c661f9416a68ac097b13fc4",
+                "sha256:c004135a300ab06a045c1c0d8e3f10215e71d7b4f5bb9a42ab80236364429937",
+                "sha256:c38876106cb6132259683632b287238858bd58de267d80defb6f418e9ee50658",
+                "sha256:ce4a17920ec144647d448fc43725b5873548b1aae6c603225626747ededf582d",
+                "sha256:d30ba01c0f151998f367506fab31c2ac4527e6a7b2690107c7a7f9e3cb419a9c",
+                "sha256:d96b196e5c16f41b4f7736840e8455958e832871990c7ba26bf58175e357ed61",
+                "sha256:e5d7ccc08ba089c06e2f5629c660388ef1fee708444f1dee0b9203fa031dee03",
+                "sha256:eafaf8b9252734400f9b77df98b4eee3d2eecab16104680d51341c75702cad70",
+                "sha256:f105f61a5eff52e137fd73bee32958b2add9d9f0a856f17314018646af838e97",
+                "sha256:f773c6d14dcc108a5b141b4456b0871df638eb411a89cd1c0c001fc4a9d08fc8",
+                "sha256:f7fb09d05e0f1c329a36dcd30e27564a3555717cde87301fae4fb542402ddfad",
+                "sha256:f8e08de6138043108b3b18f09d3f817a4783912e48828ab397ecf183135d84d6",
+                "sha256:f986f1cab8dbec39ba6e0eaa42d4d3ac6686516a5d3dccd64be095db05ebc6bb"
             ],
             "index": "pypi",
             "markers": "python_version >= '3.9'",
-            "version": "==1.16.1"
+            "version": "==1.17.0"
         },
         "mypy-boto3-cloudformation": {
             "hashes": [
-                "sha256:1016508783c1263aba9bb24dd29afbea6f0c8c7cee79e9d073c4ed5524ce53f5",
-                "sha256:f4185231faab97bfb50b25dc1323333c630a092ffa8c15356f21116fc92a7f42"
+                "sha256:734a9432dd9dbc58262424da6d04a4962cac6810c17a9933e6438180d2254129",
+                "sha256:d19c4c5d6d6e0f1eec9061ebe4a50ef46c113f775cf01599e880809a9f0da7c4"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==1.38.31"
+            "version": "==1.39.0"
         },
         "mypy-boto3-dynamodb": {
             "hashes": [
-                "sha256:5cf3787631e312b3d75f89a6cbbbd4ad786a76f5d565af023febf03fbf23c0b5",
-                "sha256:6b29d89c649eeb1e894118bee002cb8b1304c78da735b1503aa08e46b0abfdec"
+                "sha256:3a136f9d764fa5e1b2ff464fa9599533fd00e65affe47bd28a40d920ece707a4",
+                "sha256:c3bafc7b4f8d59bac9a7436c7ccfb6fe32991bc7fc88c62264eaad06ae63f8a8"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==1.38.4"
+            "version": "==1.39.0"
         },
         "mypy-boto3-ec2": {
             "hashes": [
-                "sha256:5d07fc10d5f682f8570000ba53bdec00ee498171509943877451c2cccbc341a3",
-                "sha256:9750403a6ad135e676ecc280acee9f0d7762f46c5bc8d864ec7c2ad3ef6118b7"
+                "sha256:830c5badf97ee4b8ed6c563aa4697b7231cf338965ea0dbdca227232f4e4c3ce",
+                "sha256:dee450e8586e45adb13c6cd0a369edddc047d88ced90345986ab9a35fb4a8f5e"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==1.38.33"
+            "version": "==1.39.12"
         },
         "mypy-boto3-lambda": {
             "hashes": [
-                "sha256:0dcb882826f61fd2751f6b98330b0e11085570654db85318aea018374ca88dc9",
-                "sha256:ece7b3848c045e1be81c4f2b7482002c17ce7cb70de850661146103a8cb1a3fb"
+                "sha256:19ad0649bf768e68840a429306aef002bbdf90f9a91512f7efd8292ca88be892",
+                "sha256:a9867ba54ced8cfd1e977afaee053d1264c8d64ef215fe8d132b9a3a4736fe07"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==1.38.0"
+            "version": "==1.39.11"
         },
         "mypy-boto3-rds": {
             "hashes": [
-                "sha256:46ceae368e950936d8092a71408f09b001bebb94c57600aa1f0ae42525f51d85",
-                "sha256:4888ecaf09c42365e76af3e7f931c7924ccea83341d4268f400b352bcf340e7c"
+                "sha256:5bc0bedd45b7d3e4a1aa8fe01d8b4837f46da4f87b4afabca8a165b4886e611b",
+                "sha256:6b95bb34f3f13e5c4e9029470828a4706845304370df773221622ee9d5d00033"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==1.38.35"
+            "version": "==1.39.1"
         },
         "mypy-boto3-s3": {
             "hashes": [
-                "sha256:1129d64be1aee863e04f0c92ac8d315578f13ccae64fa199b20ad0950d2b9616",
-                "sha256:38a45dee5782d5c07ddea07ea50965c4d2ba7e77617c19f613b4c9f80f961b52"
+                "sha256:57272e73faf0d38e65b5ed82c8b22650c8820c8d070c5b10e307fd98f247e05a",
+                "sha256:b339a9128e96eaf74f87c40ee42711db82d31a45085ba78b262ae7683cb9e5f0"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==1.38.26"
+            "version": "==1.39.5"
         },
         "mypy-boto3-sqs": {
             "hashes": [
-                "sha256:39aebc121a2fe20f962fd83b617fd916003605d6f6851fdf195337a0aa428fe1",
-                "sha256:8e881c8492f6f51dcbe1cce9d9f05334f4b256b5843e227fa925e0f6e702b31d"
+                "sha256:279d489e9b8ffb860f2dc6349608e9eb289ae0c8c3558739e9e62c595e456834",
+                "sha256:ca434295143f811a9b8a1e9fd81f19a7213c3590ced5131cb648fc2107f4eaba"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==1.38.0"
+            "version": "==1.39.0"
         },
         "mypy-extensions": {
             "hashes": [
@@ -1333,11 +1321,11 @@
         },
         "py-serializable": {
             "hashes": [
-                "sha256:1721e4c0368adeec965c183168da4b912024702f19e15e13f8577098b9a4f8fe",
-                "sha256:e9e6491dd7d29c31daf1050232b57f9657f9e8a43b867cca1ff204752cf420a5"
+                "sha256:9d5db56154a867a9b897c0163b33a793c804c80cee984116d02d49e4578fc103",
+                "sha256:b56d5d686b5a03ba4f4db5e769dc32336e142fc3bd4d68a8c25579ebb0a67304"
             ],
             "markers": "python_version >= '3.8' and python_version < '4.0'",
-            "version": "==2.0.0"
+            "version": "==2.1.0"
         },
         "pycparser": {
             "hashes": [
@@ -1349,11 +1337,11 @@
         },
         "pygments": {
             "hashes": [
-                "sha256:61c16d2a8576dc0649d9f39e089b5f02bcd27fba10d8fb4dcc28173f7a45151f",
-                "sha256:9ea1544ad55cecf4b8242fab6dd35a93bbce657034b0611ee383099054ab6d8c"
+                "sha256:636cb2477cec7f8952536970bc533bc43743542f70392ae026374600add5b887",
+                "sha256:86540386c03d588bb81d44bc3928634ff26449851e99741617ecb9037ee5ec0b"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==2.19.1"
+            "version": "==2.19.2"
         },
         "pyparsing": {
             "hashes": [
@@ -1465,36 +1453,36 @@
         },
         "ruff": {
             "hashes": [
-                "sha256:05ed0c914fabc602fc1f3b42c53aa219e5736cb030cdd85640c32dbc73da74a6",
-                "sha256:07a7aa9b69ac3fcfda3c507916d5d1bca10821fe3797d46bad10f2c6de1edda0",
-                "sha256:0c0758038f81beec8cc52ca22de9685b8ae7f7cc18c013ec2050012862cc9165",
-                "sha256:139b3d28027987b78fc8d6cfb61165447bdf3740e650b7c480744873688808c2",
-                "sha256:1e55e44e770e061f55a7dbc6e9aed47feea07731d809a3710feda2262d2d4d8a",
-                "sha256:3a9512af224b9ac4757f7010843771da6b2b0935a9e5e76bb407caa901a1a514",
-                "sha256:4d047db3662418d4a848a3fdbfaf17488b34b62f527ed6f10cb8afd78135bc5c",
-                "sha256:5652a9ecdb308a1754d96a68827755f28d5dfb416b06f60fd9e13f26191a8848",
-                "sha256:68853e8517b17bba004152aebd9dd77d5213e503a5f2789395b25f26acac0da4",
-                "sha256:6a315992297a7435a66259073681bb0d8647a826b7a6de45c6934b2ca3a9ed51",
-                "sha256:7162a4c816f8d1555eb195c46ae0bd819834d2a3f18f98cc63819a7b46f474fb",
-                "sha256:7d235618283718ee2fe14db07f954f9b2423700919dc688eacf3f8797a11315c",
-                "sha256:8cd24580405ad8c1cc64d61725bca091d6b6da7eb3d36f72cc605467069d7e8b",
-                "sha256:952d0630eae628250ab1c70a7fffb641b03e6b4a2d3f3ec6c1d19b4ab6c6c807",
-                "sha256:b08df3d96db798e5beb488d4df03011874aff919a97dcc2dd8539bb2be5d6a88",
-                "sha256:c021f04ea06966b02614d442e94071781c424ab8e02ec7af2f037b4c1e01cc82",
-                "sha256:d00b7a157b8fb6d3827b49d3324da34a1e3f93492c1f97b08e222ad7e9b291e0",
-                "sha256:e7731c3eec50af71597243bace7ec6104616ca56dda2b99c89935fe926bdcd48"
+                "sha256:1de2c887e9dec6cb31fcb9948299de5b2db38144e66403b9660c9548a67abd92",
+                "sha256:2c47dea6ae39421851685141ba9734767f960113d51e83fd7bb9958d5be8763a",
+                "sha256:46699f73c2b5b137b9dc0fc1a190b43e35b008b398c6066ea1350cce6326adcb",
+                "sha256:48cdbfc633de2c5c37d9f090ba3b352d1576b0015bfc3bc98eaf230275b7e805",
+                "sha256:5a655a0a0d396f0f072faafc18ebd59adde8ca85fb848dc1b0d9f024b9c4d3bb",
+                "sha256:73b4cae449597e7195a49eb1cdca89fd9fbb16140c7579899e87f4c85bf82f73",
+                "sha256:8b13489c3dc50de5e2d40110c0cce371e00186b880842e245186ca862bf9a1ac",
+                "sha256:8dbbf9f25dfb501f4237ae7501d6364b76a01341c6f1b2cd6764fe449124bb2a",
+                "sha256:962775ed5b27c7aa3fdc0d8f4d4433deae7659ef99ea20f783d666e77338b8cf",
+                "sha256:a5a4c7830dadd3d8c39b1cc85386e2c1e62344f20766be6f173c22fb5f72f293",
+                "sha256:ae0d90cf5f49466c954991b9d8b953bd093c32c27608e409ae3564c63c5306a5",
+                "sha256:b209db6102b66f13625940b7f8c7d0f18e20039bb7f6101fbdac935c9612057e",
+                "sha256:c5076aa0e61e30f848846f0265c873c249d4b558105b221be1828f9f79903dc5",
+                "sha256:c7da4129016ae26c32dfcbd5b671fe652b5ab7fc40095d80dcff78175e7eddd4",
+                "sha256:ca972c80f7ebcfd8af75a0f18b17c42d9f1ef203d163669150453f50ca98ab7b",
+                "sha256:d1ab65e7d8152f519e7dea4de892317c9da7a108da1c56b6a3c1d5e7cf4c5e9a",
+                "sha256:dfeb2627c459b0b78ca2bbdc38dd11cc9a0a88bf91db982058b26ce41714ffa9",
+                "sha256:f1504fea81461cf4841778b3ef0a078757602a3b3ea4b008feb1308cb3f23e08"
             ],
             "index": "pypi",
             "markers": "python_version >= '3.7'",
-            "version": "==0.12.0"
+            "version": "==0.12.5"
         },
         "s3transfer": {
             "hashes": [
-                "sha256:0148ef34d6dd964d0d8cf4311b2b21c474693e57c2e069ec708ce043d2b527be",
-                "sha256:f5e6db74eb7776a37208001113ea7aa97695368242b364d73e91c981ac522177"
+                "sha256:a981aa7429be23fe6dfc13e80e4020057cbab622b08c0315288758d67cabc724",
+                "sha256:c3fdba22ba1bd367922f27ec8032d6a1cf5f10c934fb5d68cf60fd5a23d936cf"
             ],
             "markers": "python_version >= '3.9'",
-            "version": "==0.13.0"
+            "version": "==0.13.1"
         },
         "six": {
             "hashes": [
@@ -1536,11 +1524,11 @@
         },
         "types-awscrt": {
             "hashes": [
-                "sha256:49a045f25bbd5ad2865f314512afced933aed35ddbafc252e2268efa8a787e4e",
-                "sha256:acd04f57119eb15626ab0ba9157fc24672421de56e7bd7b9f61681fedee44e91"
+                "sha256:a8c4b9d9ae66d616755c322aba75ab9bd793c6fef448917e6de2e8b8cdf66fb4",
+                "sha256:c019ba91a097e8a31d6948f6176ede1312963f41cdcacf82482ac877cbbcf390"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==0.27.2"
+            "version": "==0.27.4"
         },
         "types-s3transfer": {
             "hashes": [
@@ -1552,11 +1540,11 @@
         },
         "typing-extensions": {
             "hashes": [
-                "sha256:8676b788e32f02ab42d9e7c61324048ae4c6d844a399eebace3d4979d75ceef4",
-                "sha256:a1514509136dd0b477638fc68d6a91497af5076466ad0fa6c338e44e359944af"
+                "sha256:38b39f4aeeab64884ce9f74c94263ef78f3c22467c8724005483154c26648d36",
+                "sha256:d1e1e3b58374dc93031d6eda2420a48ea44a36c2b4766a4fdeb3710755731d76"
             ],
             "markers": "python_version >= '3.9'",
-            "version": "==4.14.0"
+            "version": "==4.14.1"
         },
         "urllib3": {
             "hashes": [
@@ -1568,11 +1556,11 @@
         },
         "virtualenv": {
             "hashes": [
-                "sha256:36efd0d9650ee985f0cad72065001e66d49a6f24eb44d98980f630686243cf11",
-                "sha256:e10c0a9d02835e592521be48b332b6caee6887f332c111aa79a09b9e79efc2af"
+                "sha256:2c310aecb62e5aa1b06103ed7c2977b81e042695de2697d01017ff0f1034af56",
+                "sha256:886bf75cadfdc964674e6e33eb74d787dff31ca314ceace03ca5810620f4ecf0"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==20.31.2"
+            "version": "==20.32.0"
         },
         "wcwidth": {
             "hashes": [

--- a/README.md
+++ b/README.md
@@ -178,9 +178,7 @@ WORKSPACE=### Set to `dev` for local development; this will be set to `stage` an
 
 ### Optional
 
-```shell
-ETL_VERSION=### Version number of the TIMDEX ETL infrastructure. This can be used to align application behavior with the requirements of other applications in the TIMDEX ETL pipeline.
-```
+None at this time.
 
 
 

--- a/lambdas/alma_prep.py
+++ b/lambdas/alma_prep.py
@@ -1,5 +1,4 @@
 import logging
-import os
 import tarfile
 from collections.abc import Generator
 from typing import IO, TYPE_CHECKING
@@ -11,8 +10,11 @@ if TYPE_CHECKING:
     from mypy_boto3_s3.client import S3Client  # pragma: no cover
 
 from lambdas import helpers
+from lambdas.config import Config
 
 logger = logging.getLogger(__name__)
+
+CONFIG = Config()
 
 
 def extract_file_from_source_bucket_to_target_bucket(
@@ -100,7 +102,7 @@ def prepare_alma_export_files(run_date: str, run_type: str, timdex_bucket: str) 
     then performs the extract, unzip, rename and upload steps.
     """
     export_job_date = run_date.replace("-", "")
-    alma_bucket = os.environ["TIMDEX_ALMA_EXPORT_BUCKET_ID"]
+    alma_bucket = CONFIG.alma_export_bucket
     alma_export_files = helpers.list_s3_files_by_prefix(
         alma_bucket,
         f"exlibris/timdex/TIMDEX_ALMA_EXPORT_{run_type.upper()}_{export_job_date}",

--- a/lambdas/commands.py
+++ b/lambdas/commands.py
@@ -1,8 +1,11 @@
 import logging
 
-from lambdas import config, helpers
+from lambdas import helpers
+from lambdas.config import Config
 
 logger = logging.getLogger(__name__)
+
+CONFIG = Config()
 
 
 def generate_extract_command(
@@ -28,7 +31,7 @@ def generate_extract_command(
     if verbose:
         extract_command.append("--verbose")
 
-    if source in config.GIS_SOURCES:
+    if source in CONFIG.GIS_SOURCES:
         extract_command.append("harvest")
         if run_type == "daily":
             extract_command.append("--harvest-type=incremental")
@@ -115,7 +118,7 @@ def generate_load_commands(
         new_index_name = helpers.generate_index_name(source)
         update_command.extend(["--index", new_index_name, dataset_location])
         promote_index_command = ["promote", "--index", new_index_name]
-        for alias, sources in config.INDEX_ALIASES.items():
+        for alias, sources in CONFIG.INDEX_ALIASES.items():
             if source in sources:
                 promote_index_command.append("--alias")
                 promote_index_command.append(alias)

--- a/lambdas/commands.py
+++ b/lambdas/commands.py
@@ -83,7 +83,7 @@ def generate_transform_commands(
     for extract_output_file in extract_output_files:
         transform_command = [
             f"--input-file=s3://{timdex_bucket}/{extract_output_file}",
-            f"--output-location=s3://{timdex_bucket}/dataset",
+            f"--output-location={CONFIG.s3_etl_records_data_location}",
             f"--source={source}",
             f"--run-id={run_id}",
             f"--run-timestamp={run_timestamp}",
@@ -97,11 +97,8 @@ def generate_load_commands(
     run_date: str,
     run_type: str,
     run_id: str,
-    timdex_bucket: str,
 ) -> dict:
     """Generate task run command for TIMDEX load."""
-    dataset_location = f"s3://{timdex_bucket}/dataset"
-
     update_command = [
         "bulk-update",
         "--run-date",
@@ -111,12 +108,14 @@ def generate_load_commands(
     ]
 
     if run_type == "daily":
-        update_command.extend(["--source", source, dataset_location])
+        update_command.extend(["--source", source, CONFIG.s3_etl_records_data_location])
         return {"bulk-update-command": update_command}
 
     if run_type == "full":
         new_index_name = helpers.generate_index_name(source)
-        update_command.extend(["--index", new_index_name, dataset_location])
+        update_command.extend(
+            ["--index", new_index_name, CONFIG.s3_etl_records_data_location]
+        )
         promote_index_command = ["promote", "--index", new_index_name]
         for alias, sources in CONFIG.INDEX_ALIASES.items():
             if source in sources:

--- a/lambdas/commands.py
+++ b/lambdas/commands.py
@@ -83,7 +83,7 @@ def generate_transform_commands(
     for extract_output_file in extract_output_files:
         transform_command = [
             f"--input-file=s3://{timdex_bucket}/{extract_output_file}",
-            f"--output-location={CONFIG.s3_etl_records_data_location}",
+            f"--output-location={CONFIG.s3_timdex_dataset_data_location}",
             f"--source={source}",
             f"--run-id={run_id}",
             f"--run-timestamp={run_timestamp}",
@@ -108,13 +108,19 @@ def generate_load_commands(
     ]
 
     if run_type == "daily":
-        update_command.extend(["--source", source, CONFIG.s3_etl_records_data_location])
+        update_command.extend(
+            [
+                "--source",
+                source,
+                CONFIG.s3_timdex_dataset_data_location,
+            ]
+        )
         return {"bulk-update-command": update_command}
 
     if run_type == "full":
         new_index_name = helpers.generate_index_name(source)
         update_command.extend(
-            ["--index", new_index_name, CONFIG.s3_etl_records_data_location]
+            ["--index", new_index_name, CONFIG.s3_timdex_dataset_data_location]
         )
         promote_index_command = ["promote", "--index", new_index_name]
         for alias, sources in CONFIG.INDEX_ALIASES.items():

--- a/lambdas/config.py
+++ b/lambdas/config.py
@@ -93,6 +93,6 @@ class Config:
         return os.environ["TIMDEX_S3_EXTRACT_BUCKET_ID"]
 
     @property
-    def s3_etl_records_data_location(self) -> str:
+    def s3_timdex_dataset_data_location(self) -> str:
         """Return full S3 URI (bucket + prefix) of ETL records data location."""
         return f"s3://{self.timdex_bucket}/dataset/data/records"

--- a/lambdas/config.py
+++ b/lambdas/config.py
@@ -44,46 +44,6 @@ class Config:
             return verbose
         return verbose.lower() == "true"
 
-    @classmethod
-    def configure_logger(
-        cls,
-        root_logger: logging.Logger,
-        *,
-        verbose: bool = False,
-        warning_only_loggers: str | None = None,
-    ) -> str:
-        """Configure application via passed application root logger.
-
-        If verbose=True, 3rd party libraries can be quite chatty.  For convenience, they
-        can be set to WARNING level by either passing a comma seperated list of logger
-        names to 'warning_only_loggers' or by setting the env var WARNING_ONLY_LOGGERS.
-        """
-        if verbose:
-            root_logger.setLevel(logging.DEBUG)
-            logging_format = (
-                "%(asctime)s %(levelname)s %(name)s.%(funcName)s() "
-                "line %(lineno)d: %(message)s"
-            )
-        else:
-            root_logger.setLevel(logging.INFO)
-            logging_format = (
-                "%(asctime)s %(levelname)s %(name)s.%(funcName)s(): %(message)s"
-            )
-
-        warning_only_loggers = os.getenv("WARNING_ONLY_LOGGERS", warning_only_loggers)
-        if warning_only_loggers:
-            for name in warning_only_loggers.split(","):
-                logging.getLogger(name).setLevel(logging.WARNING)
-
-        handler = logging.StreamHandler()
-        handler.setFormatter(logging.Formatter(logging_format))
-        root_logger.addHandler(handler)
-
-        return (
-            f"Logger '{root_logger.name}' configured with level="
-            f"{logging.getLevelName(root_logger.getEffectiveLevel())}"
-        )
-
     @property
     def alma_export_bucket(self) -> str:
         return os.environ["TIMDEX_ALMA_EXPORT_BUCKET_ID"]
@@ -96,3 +56,40 @@ class Config:
     def s3_timdex_dataset_data_location(self) -> str:
         """Return full S3 URI (bucket + prefix) of ETL records data location."""
         return f"s3://{self.timdex_bucket}/dataset/data/records"
+
+
+def configure_logger(
+    root_logger: logging.Logger,
+    *,
+    verbose: bool = False,
+    warning_only_loggers: str | None = None,
+) -> str:
+    """Configure application via passed application root logger.
+
+    If verbose=True, 3rd party libraries can be quite chatty.  For convenience, they
+    can be set to WARNING level by either passing a comma seperated list of logger
+    names to 'warning_only_loggers' or by setting the env var WARNING_ONLY_LOGGERS.
+    """
+    if verbose:
+        root_logger.setLevel(logging.DEBUG)
+        logging_format = (
+            "%(asctime)s %(levelname)s %(name)s.%(funcName)s() "
+            "line %(lineno)d: %(message)s"
+        )
+    else:
+        root_logger.setLevel(logging.INFO)
+        logging_format = "%(asctime)s %(levelname)s %(name)s.%(funcName)s(): %(message)s"
+
+    warning_only_loggers = os.getenv("WARNING_ONLY_LOGGERS", warning_only_loggers)
+    if warning_only_loggers:
+        for name in warning_only_loggers.split(","):
+            logging.getLogger(name).setLevel(logging.WARNING)
+
+    handler = logging.StreamHandler()
+    handler.setFormatter(logging.Formatter(logging_format))
+    root_logger.addHandler(handler)
+
+    return (
+        f"Logger '{root_logger.name}' configured with level="
+        f"{logging.getLevelName(root_logger.getEffectiveLevel())}"
+    )

--- a/lambdas/config.py
+++ b/lambdas/config.py
@@ -38,7 +38,7 @@ class Config:
             raise OSError(message)
 
     @staticmethod
-    def check_verbosity(verbose: bool | str) -> bool:  # noqa: FBT001
+    def get_verbose_flag(verbose: bool | str) -> bool:  # noqa: FBT001
         """Determine whether verbose is True or False given a boolean or string value."""
         if isinstance(verbose, bool):
             return verbose

--- a/lambdas/config.py
+++ b/lambdas/config.py
@@ -84,55 +84,6 @@ class Config:
             f"{logging.getLevelName(root_logger.getEffectiveLevel())}"
         )
 
-    @classmethod
-    def validate_input(cls, input_data: dict) -> None:
-        """Validate input to the lambda function.
-
-        Ensures that all requiered input fields are present and contain valid data.
-        """
-        # All required fields are present
-        if missing_fields := [
-            field for field in cls.REQUIRED_FIELDS if field not in input_data
-        ]:
-            message = (
-                "Input must include all required fields. "
-                f"Missing fields: {missing_fields}"
-            )
-            raise ValueError(message)
-
-        # Valid next step
-        next_step = input_data["next-step"]
-        if next_step not in cls.VALID_STEPS:
-            message = (
-                f"Input 'next-step' value must be one of: {cls.VALID_STEPS}. Value "
-                f"provided was '{next_step}'"
-            )
-            raise ValueError(message)
-
-        # Valid run type
-        run_type = input_data["run-type"]
-        if run_type not in cls.VALID_RUN_TYPES:
-            message = (
-                f"Input 'run-type' value must be one of: {cls.VALID_RUN_TYPES}. Value "
-                f"provided was '{run_type}'"
-            )
-            raise ValueError(message)
-
-        # If next step is extract step, required harvest fields are present
-        # ruff: noqa: SIM102
-        if input_data["next-step"] == "extract":
-            if input_data["source"] not in cls.GIS_SOURCES:
-                if missing_harvest_fields := [
-                    field
-                    for field in cls.REQUIRED_OAI_HARVEST_FIELDS
-                    if field not in input_data
-                ]:
-                    message = (
-                        "Input must include all required harvest fields when starting "
-                        f"with harvest step. Missing fields: {missing_harvest_fields}"
-                    )
-                    raise ValueError(message)
-
     @property
     def alma_export_bucket(self) -> str:
         return os.environ["TIMDEX_ALMA_EXPORT_BUCKET_ID"]

--- a/lambdas/config.py
+++ b/lambdas/config.py
@@ -132,3 +132,11 @@ class Config:
                         f"with harvest step. Missing fields: {missing_harvest_fields}"
                     )
                     raise ValueError(message)
+
+    @property
+    def alma_export_bucket(self) -> str:
+        return os.environ["TIMDEX_ALMA_EXPORT_BUCKET_ID"]
+
+    @property
+    def timdex_bucket(self) -> str:
+        return os.environ["TIMDEX_S3_EXTRACT_BUCKET_ID"]

--- a/lambdas/config.py
+++ b/lambdas/config.py
@@ -1,3 +1,5 @@
+# ruff: noqa: EM102, TRY003
+
 import logging
 import os
 from typing import Any, ClassVar
@@ -46,11 +48,19 @@ class Config:
 
     @property
     def alma_export_bucket(self) -> str:
-        return os.environ["TIMDEX_ALMA_EXPORT_BUCKET_ID"]
+        var = "TIMDEX_ALMA_EXPORT_BUCKET_ID"
+        value = os.getenv(var)
+        if not value:
+            raise OSError(f"Env var '{var}' must be defined")
+        return value
 
     @property
     def timdex_bucket(self) -> str:
-        return os.environ["TIMDEX_S3_EXTRACT_BUCKET_ID"]
+        var = "TIMDEX_S3_EXTRACT_BUCKET_ID"
+        value = os.getenv(var)
+        if not value:
+            raise OSError(f"Env var '{var}' must be defined")
+        return value
 
     @property
     def s3_timdex_dataset_data_location(self) -> str:

--- a/lambdas/config.py
+++ b/lambdas/config.py
@@ -1,115 +1,134 @@
 import logging
 import os
-
-GIS_SOURCES = ["gismit", "gisogm"]
-INDEX_ALIASES = {
-    "rdi": ["jpal", "whoas", "zenodo"],
-    "timdex": ["alma", "aspace", "dspace"],
-    "geo": GIS_SOURCES,
-}
-REQUIRED_ENV = {
-    "TIMDEX_ALMA_EXPORT_BUCKET_ID",
-    "TIMDEX_S3_EXTRACT_BUCKET_ID",
-    "WORKSPACE",
-}
-REQUIRED_FIELDS = ("next-step", "run-date", "run-type", "source")
-REQUIRED_OAI_HARVEST_FIELDS = ("oai-pmh-host", "oai-metadata-format")
-VALID_DATE_FORMATS = ("%Y-%m-%d", "%Y-%m-%dT%H:%M:%SZ")
-VALID_RUN_TYPES = ("full", "daily")
-VALID_STEPS = ("extract", "transform", "load")
+from typing import Any, ClassVar
 
 
-def check_verbosity(verbose: bool | str) -> bool:  # noqa: FBT001
-    """Determine whether verbose is True or False given a boolean or string value."""
-    if isinstance(verbose, bool):
-        return verbose
-    return verbose.lower() == "true"
-
-
-def configure_logger(
-    root_logger: logging.Logger,
-    *,
-    verbose: bool = False,
-    warning_only_loggers: str | None = None,
-) -> str:
-    """Configure application via passed application root logger.
-
-    If verbose=True, 3rd party libraries can be quite chatty.  For convenience, they can
-    be set to WARNING level by either passing a comma seperated list of logger names to
-    'warning_only_loggers' or by setting the env var WARNING_ONLY_LOGGERS.
-    """
-    if verbose:
-        root_logger.setLevel(logging.DEBUG)
-        logging_format = (
-            "%(asctime)s %(levelname)s %(name)s.%(funcName)s() "
-            "line %(lineno)d: %(message)s"
-        )
-    else:
-        root_logger.setLevel(logging.INFO)
-        logging_format = "%(asctime)s %(levelname)s %(name)s.%(funcName)s(): %(message)s"
-
-    warning_only_loggers = os.getenv("WARNING_ONLY_LOGGERS", warning_only_loggers)
-    if warning_only_loggers:
-        for name in warning_only_loggers.split(","):
-            logging.getLogger(name).setLevel(logging.WARNING)
-
-    handler = logging.StreamHandler()
-    handler.setFormatter(logging.Formatter(logging_format))
-    root_logger.addHandler(handler)
-
-    return (
-        f"Logger '{root_logger.name}' configured with level="
-        f"{logging.getLevelName(root_logger.getEffectiveLevel())}"
+class Config:
+    REQUIRED_ENV_VARS = (
+        "TIMDEX_ALMA_EXPORT_BUCKET_ID",
+        "TIMDEX_S3_EXTRACT_BUCKET_ID",
+        "WORKSPACE",
     )
+    OPTIONAL_ENV_VARS = ()
 
+    GIS_SOURCES = ("gismit", "gisogm")
+    INDEX_ALIASES: ClassVar = {
+        "rdi": ["jpal", "whoas", "zenodo"],
+        "timdex": ["alma", "aspace", "dspace"],
+        "geo": GIS_SOURCES,
+    }
+    REQUIRED_FIELDS = ("next-step", "run-date", "run-type", "source")
+    REQUIRED_OAI_HARVEST_FIELDS = ("oai-pmh-host", "oai-metadata-format")
+    VALID_DATE_FORMATS = ("%Y-%m-%d", "%Y-%m-%dT%H:%M:%SZ")
+    VALID_RUN_TYPES = ("full", "daily")
+    VALID_STEPS = ("extract", "transform", "load")
 
-def validate_input(input_data: dict) -> None:
-    """Validate input to the lambda function.
+    def __getattr__(self, name: str) -> Any:  # noqa: ANN401
+        """Provide dot notation access to configurations and env vars on this class."""
+        if name in self.REQUIRED_ENV_VARS or name in self.OPTIONAL_ENV_VARS:
+            return os.getenv(name)
+        message = f"'{name}' not a valid configuration variable"
+        raise AttributeError(message)
 
-    Ensures that all requiered input fields are present and contain valid data.
-    """
-    # All required fields are present
-    if missing_fields := [field for field in REQUIRED_FIELDS if field not in input_data]:
-        message = (
-            f"Input must include all required fields. Missing fields: {missing_fields}"
+    def check_required_env_vars(self) -> None:
+        """Method to raise exception if required env vars not set."""
+        missing_vars = [var for var in self.REQUIRED_ENV_VARS if not os.getenv(var)]
+        if missing_vars:
+            message = f"Missing required environment variables: {', '.join(missing_vars)}"
+            raise OSError(message)
+
+    @staticmethod
+    def check_verbosity(verbose: bool | str) -> bool:  # noqa: FBT001
+        """Determine whether verbose is True or False given a boolean or string value."""
+        if isinstance(verbose, bool):
+            return verbose
+        return verbose.lower() == "true"
+
+    @classmethod
+    def configure_logger(
+        cls,
+        root_logger: logging.Logger,
+        *,
+        verbose: bool = False,
+        warning_only_loggers: str | None = None,
+    ) -> str:
+        """Configure application via passed application root logger.
+
+        If verbose=True, 3rd party libraries can be quite chatty.  For convenience, they
+        can be set to WARNING level by either passing a comma seperated list of logger
+        names to 'warning_only_loggers' or by setting the env var WARNING_ONLY_LOGGERS.
+        """
+        if verbose:
+            root_logger.setLevel(logging.DEBUG)
+            logging_format = (
+                "%(asctime)s %(levelname)s %(name)s.%(funcName)s() "
+                "line %(lineno)d: %(message)s"
+            )
+        else:
+            root_logger.setLevel(logging.INFO)
+            logging_format = (
+                "%(asctime)s %(levelname)s %(name)s.%(funcName)s(): %(message)s"
+            )
+
+        warning_only_loggers = os.getenv("WARNING_ONLY_LOGGERS", warning_only_loggers)
+        if warning_only_loggers:
+            for name in warning_only_loggers.split(","):
+                logging.getLogger(name).setLevel(logging.WARNING)
+
+        handler = logging.StreamHandler()
+        handler.setFormatter(logging.Formatter(logging_format))
+        root_logger.addHandler(handler)
+
+        return (
+            f"Logger '{root_logger.name}' configured with level="
+            f"{logging.getLevelName(root_logger.getEffectiveLevel())}"
         )
-        raise ValueError(message)
 
-    # Valid next step
-    next_step = input_data["next-step"]
-    if next_step not in VALID_STEPS:
-        message = (
-            f"Input 'next-step' value must be one of: {VALID_STEPS}. Value "
-            f"provided was '{next_step}'"
-        )
-        raise ValueError(message)
+    @classmethod
+    def validate_input(cls, input_data: dict) -> None:
+        """Validate input to the lambda function.
 
-    # Valid run type
-    run_type = input_data["run-type"]
-    if run_type not in VALID_RUN_TYPES:
-        message = (
-            f"Input 'run-type' value must be one of: {VALID_RUN_TYPES}. Value "
-            f"provided was '{run_type}'"
-        )
-        raise ValueError(message)
+        Ensures that all requiered input fields are present and contain valid data.
+        """
+        # All required fields are present
+        if missing_fields := [
+            field for field in cls.REQUIRED_FIELDS if field not in input_data
+        ]:
+            message = (
+                "Input must include all required fields. "
+                f"Missing fields: {missing_fields}"
+            )
+            raise ValueError(message)
 
-    # If next step is extract step, required harvest fields are present
-    # ruff: noqa: SIM102
-    if input_data["next-step"] == "extract":
-        if input_data["source"] not in GIS_SOURCES:
-            if missing_harvest_fields := [
-                field for field in REQUIRED_OAI_HARVEST_FIELDS if field not in input_data
-            ]:
-                message = (
-                    "Input must include all required harvest fields when starting with "
-                    f"harvest step. Missing fields: {missing_harvest_fields}"
-                )
-                raise ValueError(message)
+        # Valid next step
+        next_step = input_data["next-step"]
+        if next_step not in cls.VALID_STEPS:
+            message = (
+                f"Input 'next-step' value must be one of: {cls.VALID_STEPS}. Value "
+                f"provided was '{next_step}'"
+            )
+            raise ValueError(message)
 
+        # Valid run type
+        run_type = input_data["run-type"]
+        if run_type not in cls.VALID_RUN_TYPES:
+            message = (
+                f"Input 'run-type' value must be one of: {cls.VALID_RUN_TYPES}. Value "
+                f"provided was '{run_type}'"
+            )
+            raise ValueError(message)
 
-def verify_env() -> None:
-    """Confirm that required env variables are set."""
-    for key in REQUIRED_ENV:
-        if not os.getenv(key):
-            message = f"Required env variable {key} is not set"
-            raise RuntimeError(message)
+        # If next step is extract step, required harvest fields are present
+        # ruff: noqa: SIM102
+        if input_data["next-step"] == "extract":
+            if input_data["source"] not in cls.GIS_SOURCES:
+                if missing_harvest_fields := [
+                    field
+                    for field in cls.REQUIRED_OAI_HARVEST_FIELDS
+                    if field not in input_data
+                ]:
+                    message = (
+                        "Input must include all required harvest fields when starting "
+                        f"with harvest step. Missing fields: {missing_harvest_fields}"
+                    )
+                    raise ValueError(message)

--- a/lambdas/config.py
+++ b/lambdas/config.py
@@ -140,3 +140,8 @@ class Config:
     @property
     def timdex_bucket(self) -> str:
         return os.environ["TIMDEX_S3_EXTRACT_BUCKET_ID"]
+
+    @property
+    def s3_etl_records_data_location(self) -> str:
+        """Return full S3 URI (bucket + prefix) of ETL records data location."""
+        return f"s3://{self.timdex_bucket}/dataset/data/records"

--- a/lambdas/format_input.py
+++ b/lambdas/format_input.py
@@ -4,7 +4,7 @@ import uuid
 from datetime import UTC, datetime
 
 from lambdas import alma_prep, commands, errors, helpers
-from lambdas.config import Config
+from lambdas.config import Config, configure_logger
 
 logger = logging.getLogger(__name__)
 
@@ -14,7 +14,7 @@ CONFIG = Config()
 def lambda_handler(event: dict, _context: dict) -> dict:
     """Format data into the necessary input for TIMDEX pipeline processing."""
     verbose = CONFIG.get_verbose_flag(event.get("verbose", False))
-    CONFIG.configure_logger(logging.getLogger(), verbose=verbose)
+    configure_logger(logging.getLogger(), verbose=verbose)
     logger.debug(json.dumps(event))
 
     helpers.validate_input(event)

--- a/lambdas/format_input.py
+++ b/lambdas/format_input.py
@@ -13,7 +13,7 @@ CONFIG = Config()
 
 def lambda_handler(event: dict, _context: dict) -> dict:
     """Format data into the necessary input for TIMDEX pipeline processing."""
-    verbose = CONFIG.check_verbosity(event.get("verbose", False))
+    verbose = CONFIG.get_verbose_flag(event.get("verbose", False))
     CONFIG.configure_logger(logging.getLogger(), verbose=verbose)
     logger.debug(json.dumps(event))
 

--- a/lambdas/format_input.py
+++ b/lambdas/format_input.py
@@ -4,18 +4,21 @@ import os
 import uuid
 from datetime import UTC, datetime
 
-from lambdas import alma_prep, commands, config, errors, helpers
+from lambdas import alma_prep, commands, errors, helpers
+from lambdas.config import Config
 
 logger = logging.getLogger(__name__)
+
+CONFIG = Config()
 
 
 def lambda_handler(event: dict, _context: dict) -> dict:
     """Format data into the necessary input for TIMDEX pipeline processing."""
-    config.verify_env()
-    verbose = config.check_verbosity(event.get("verbose", False))
-    config.configure_logger(logging.getLogger(), verbose=verbose)
+    verbose = CONFIG.check_verbosity(event.get("verbose", False))
+    CONFIG.configure_logger(logging.getLogger(), verbose=verbose)
     logger.debug(json.dumps(event))
-    config.validate_input(event)
+
+    CONFIG.validate_input(event)
 
     run_date = helpers.format_run_date(event["run-date"])
     run_type = event["run-type"]
@@ -33,7 +36,7 @@ def lambda_handler(event: dict, _context: dict) -> dict:
     }
 
     if next_step == "extract":
-        if source in config.GIS_SOURCES:
+        if source in CONFIG.GIS_SOURCES:
             result["harvester-type"] = "geo"
         else:
             result["harvester-type"] = "oai"

--- a/lambdas/format_input.py
+++ b/lambdas/format_input.py
@@ -92,11 +92,7 @@ def lambda_handler(event: dict, _context: dict) -> dict:
         return result
 
     if next_step == "load":
-        if not helpers.dataset_records_exist_for_run(
-            CONFIG.timdex_bucket,
-            run_date,
-            run_id,
-        ):
+        if not helpers.dataset_records_exist_for_run(run_date, run_id):
             result["failure"] = (
                 "No records were found in the TIMDEX dataset for run_date "
                 f"'{run_date}', run_id '{run_id}'."
@@ -107,7 +103,6 @@ def lambda_handler(event: dict, _context: dict) -> dict:
             run_date,
             run_type,
             run_id,
-            CONFIG.timdex_bucket,
         )
         return result
 

--- a/lambdas/format_input.py
+++ b/lambdas/format_input.py
@@ -17,7 +17,7 @@ def lambda_handler(event: dict, _context: dict) -> dict:
     CONFIG.configure_logger(logging.getLogger(), verbose=verbose)
     logger.debug(json.dumps(event))
 
-    CONFIG.validate_input(event)
+    helpers.validate_input(event)
 
     run_date = helpers.format_run_date(event["run-date"])
     run_type = event["run-type"]

--- a/lambdas/format_input.py
+++ b/lambdas/format_input.py
@@ -1,6 +1,5 @@
 import json
 import logging
-import os
 import uuid
 from datetime import UTC, datetime
 
@@ -26,7 +25,6 @@ def lambda_handler(event: dict, _context: dict) -> dict:
     next_step = event["next-step"]
     run_id = event.get("run-id", str(uuid.uuid4()))
     run_timestamp = event.get("run-timestamp", datetime.now(UTC).isoformat())
-    timdex_bucket = os.environ["TIMDEX_S3_EXTRACT_BUCKET_ID"]
 
     result = {
         "run-date": run_date,
@@ -42,18 +40,28 @@ def lambda_handler(event: dict, _context: dict) -> dict:
             result["harvester-type"] = "oai"
         result["next-step"] = "transform"
         result["extract"] = commands.generate_extract_command(
-            event, run_date, timdex_bucket, verbose
+            event,
+            run_date,
+            CONFIG.timdex_bucket,
+            verbose,
         )
         return result
 
     if next_step == "transform":
         try:
             if source == "alma":
-                alma_prep.prepare_alma_export_files(run_date, run_type, timdex_bucket)
+                alma_prep.prepare_alma_export_files(
+                    run_date,
+                    run_type,
+                    CONFIG.timdex_bucket,
+                )
             extract_output_files = helpers.list_s3_files_by_prefix(
-                timdex_bucket,
+                CONFIG.timdex_bucket,
                 helpers.generate_step_output_prefix(
-                    source, run_date, run_type, "extract"
+                    source,
+                    run_date,
+                    run_type,
+                    "extract",
                 ),
             )
         except errors.NoFilesError:
@@ -75,19 +83,31 @@ def lambda_handler(event: dict, _context: dict) -> dict:
         )
         result["next-step"] = "load"
         result["transform"] = commands.generate_transform_commands(
-            extract_output_files, event, timdex_bucket, run_id, run_timestamp
+            extract_output_files,
+            event,
+            CONFIG.timdex_bucket,
+            run_id,
+            run_timestamp,
         )
         return result
 
     if next_step == "load":
-        if not helpers.dataset_records_exist_for_run(timdex_bucket, run_date, run_id):
+        if not helpers.dataset_records_exist_for_run(
+            CONFIG.timdex_bucket,
+            run_date,
+            run_id,
+        ):
             result["failure"] = (
                 "No records were found in the TIMDEX dataset for run_date "
                 f"'{run_date}', run_id '{run_id}'."
             )
             return result
         result["load"] = commands.generate_load_commands(
-            source, run_date, run_type, run_id, timdex_bucket
+            source,
+            run_date,
+            run_type,
+            run_id,
+            CONFIG.timdex_bucket,
         )
         return result
 

--- a/lambdas/helpers.py
+++ b/lambdas/helpers.py
@@ -165,6 +165,6 @@ def dataset_records_exist_for_run(run_date: str, run_id: str) -> bool:
     action is "index" or "delete".  If zero records exist, or have action "skip" or
     "error", we do not need to perform any load commands.
     """
-    td = TIMDEXDataset(location=CONFIG.s3_etl_records_data_location)
+    td = TIMDEXDataset(location=CONFIG.s3_timdex_dataset_data_location)
     td.load(run_date=run_date, run_id=run_id, action=["index", "delete"])
     return td.row_count > 0

--- a/lambdas/helpers.py
+++ b/lambdas/helpers.py
@@ -109,7 +109,7 @@ def list_s3_files_by_prefix(bucket: str, prefix: str) -> list[str]:
     return s3_files
 
 
-def dataset_records_exist_for_run(bucket: str, run_date: str, run_id: str) -> bool:
+def dataset_records_exist_for_run(run_date: str, run_id: str) -> bool:
     """Query TIMDEX dataset to confirm records to load and/or delete.
 
     A "run" is defined by a run-date + run-id, both provided as inputs to this lambda
@@ -117,6 +117,6 @@ def dataset_records_exist_for_run(bucket: str, run_date: str, run_id: str) -> bo
     action is "index" or "delete".  If zero records exist, or have action "skip" or
     "error", we do not need to perform any load commands.
     """
-    td = TIMDEXDataset(location=f"s3://{bucket}/dataset")
+    td = TIMDEXDataset(location=CONFIG.s3_etl_records_data_location)
     td.load(run_date=run_date, run_id=run_id, action=["index", "delete"])
     return td.row_count > 0

--- a/lambdas/helpers.py
+++ b/lambdas/helpers.py
@@ -5,9 +5,12 @@ from datetime import UTC, datetime, timedelta
 import boto3
 from timdex_dataset_api.dataset import TIMDEXDataset  # type: ignore[import-untyped]
 
-from lambdas import config, errors
+from lambdas import errors
+from lambdas.config import Config
 
 logger = logging.getLogger(__name__)
+
+CONFIG = Config()
 
 
 def format_run_date(input_date: str) -> str:
@@ -18,14 +21,14 @@ def format_run_date(input_date: str) -> str:
     index names, YYYY-MM-DD.
     """
     input_date_object = None
-    for date_format in config.VALID_DATE_FORMATS:
+    for date_format in CONFIG.VALID_DATE_FORMATS:
         with contextlib.suppress(ValueError):
             input_date_object = datetime.strptime(input_date, date_format).astimezone(UTC)
     if input_date_object:
         return input_date_object.strftime("%Y-%m-%d")
     message = (
         "Input 'run-date' value must be one of the following date string formats: "
-        f"{config.VALID_DATE_FORMATS}. Value provided was '{input_date}'"
+        f"{CONFIG.VALID_DATE_FORMATS}. Value provided was '{input_date}'"
     )
     raise ValueError(message)
 
@@ -56,7 +59,7 @@ def generate_step_output_filename(
     """
     sequence_suffix = f"_{sequence}" if sequence else ""
     if step == "extract":
-        file_type = "jsonl" if source in config.GIS_SOURCES else "xml"
+        file_type = "jsonl" if source in CONFIG.GIS_SOURCES else "xml"
     elif load_type == "delete":
         file_type = "txt"
     else:

--- a/lambdas/helpers.py
+++ b/lambdas/helpers.py
@@ -13,6 +13,54 @@ logger = logging.getLogger(__name__)
 CONFIG = Config()
 
 
+def validate_input(input_data: dict) -> None:
+    """Validate input to the lambda function.
+
+    Ensures that all required input fields are present and contain valid data.
+    """
+    # All required fields are present
+    if missing_fields := [
+        field for field in CONFIG.REQUIRED_FIELDS if field not in input_data
+    ]:
+        message = (
+            f"Input must include all required fields. Missing fields: {missing_fields}"
+        )
+        raise ValueError(message)
+
+    # Valid next step
+    next_step = input_data["next-step"]
+    if next_step not in CONFIG.VALID_STEPS:
+        message = (
+            f"Input 'next-step' value must be one of: {CONFIG.VALID_STEPS}. Value "
+            f"provided was '{next_step}'"
+        )
+        raise ValueError(message)
+
+    # Valid run type
+    run_type = input_data["run-type"]
+    if run_type not in CONFIG.VALID_RUN_TYPES:
+        message = (
+            f"Input 'run-type' value must be one of: {CONFIG.VALID_RUN_TYPES}. Value "
+            f"provided was '{run_type}'"
+        )
+        raise ValueError(message)
+
+    # If next step is extract step, required harvest fields are present
+    # ruff: noqa: SIM102
+    if input_data["next-step"] == "extract":
+        if input_data["source"] not in CONFIG.GIS_SOURCES:
+            if missing_harvest_fields := [
+                field
+                for field in CONFIG.REQUIRED_OAI_HARVEST_FIELDS
+                if field not in input_data
+            ]:
+                message = (
+                    "Input must include all required harvest fields when starting "
+                    f"with harvest step. Missing fields: {missing_harvest_fields}"
+                )
+                raise ValueError(message)
+
+
 def format_run_date(input_date: str) -> str:
     """Format an input date string into a TIMDEX date string.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,8 @@ ignore = [
     "PLR0913",
     "PLR0915",
     "S321",
+    "TD002",
+    "TD003"
 ]
 
 # allow autofix behavior for specified rules

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -99,7 +99,7 @@ def test_generate_transform_commands_required_input_fields(run_id, run_timestamp
                 "transform-command": [
                     "--input-file=s3://test-timdex-bucket/testsource/"
                     "testsource-2022-01-02-full-extracted-records-to-index.xml",
-                    "--output-location=s3://test-timdex-bucket/dataset",
+                    "--output-location=s3://test-timdex-bucket/dataset/data/records",
                     "--source=testsource",
                     f"--run-id={run_id}",
                     f"--run-timestamp={run_timestamp}",
@@ -133,7 +133,7 @@ def test_generate_transform_commands_all_input_fields(run_id, run_timestamp):
                 "transform-command": [
                     "--input-file=s3://test-timdex-bucket/testsource/"
                     "testsource-2022-01-02-daily-extracted-records-to-index_01.xml",
-                    "--output-location=s3://test-timdex-bucket/dataset",
+                    "--output-location=s3://test-timdex-bucket/dataset/data/records",
                     "--source=testsource",
                     f"--run-id={run_id}",
                     f"--run-timestamp={run_timestamp}",
@@ -143,7 +143,7 @@ def test_generate_transform_commands_all_input_fields(run_id, run_timestamp):
                 "transform-command": [
                     "--input-file=s3://test-timdex-bucket/testsource/"
                     "testsource-2022-01-02-daily-extracted-records-to-index_02.xml",
-                    "--output-location=s3://test-timdex-bucket/dataset",
+                    "--output-location=s3://test-timdex-bucket/dataset/data/records",
                     "--source=testsource",
                     f"--run-id={run_id}",
                     f"--run-timestamp={run_timestamp}",
@@ -153,7 +153,7 @@ def test_generate_transform_commands_all_input_fields(run_id, run_timestamp):
                 "transform-command": [
                     "--input-file=s3://test-timdex-bucket/testsource/"
                     "testsource-2022-01-02-daily-extracted-records-to-delete.xml",
-                    "--output-location=s3://test-timdex-bucket/dataset",
+                    "--output-location=s3://test-timdex-bucket/dataset/data/records",
                     "--source=testsource",
                     f"--run-id={run_id}",
                     f"--run-timestamp={run_timestamp}",
@@ -169,7 +169,6 @@ def test_generate_load_commands_daily(run_id):
         "2022-01-02",
         "daily",
         "run-abc-123",
-        "test-timdex-bucket",
     ) == {
         "bulk-update-command": [
             "bulk-update",
@@ -179,7 +178,7 @@ def test_generate_load_commands_daily(run_id):
             "run-abc-123",
             "--source",
             "testsource",
-            "s3://test-timdex-bucket/dataset",
+            "s3://test-timdex-bucket/dataset/data/records",
         ]
     }
 
@@ -191,7 +190,6 @@ def test_generate_load_commands_full_no_alias(run_id):
         "2022-01-02",
         "full",
         "run-abc-123",
-        "test-timdex-bucket",
     ) == {
         "create-index-command": ["create", "--index", "testsource-2022-01-02t12-13-14"],
         "bulk-update-command": [
@@ -202,7 +200,7 @@ def test_generate_load_commands_full_no_alias(run_id):
             "run-abc-123",
             "--index",
             "testsource-2022-01-02t12-13-14",
-            "s3://test-timdex-bucket/dataset",
+            "s3://test-timdex-bucket/dataset/data/records",
         ],
         "promote-index-command": ["promote", "--index", "testsource-2022-01-02t12-13-14"],
     }
@@ -215,7 +213,6 @@ def test_generate_load_commands_full_with_alias(run_id):
         "2022-01-02",
         "full",
         "run-abc-123",
-        "test-timdex-bucket",
     ) == {
         "create-index-command": ["create", "--index", "alma-2022-01-02t12-13-14"],
         "bulk-update-command": [
@@ -226,7 +223,7 @@ def test_generate_load_commands_full_with_alias(run_id):
             "run-abc-123",
             "--index",
             "alma-2022-01-02t12-13-14",
-            "s3://test-timdex-bucket/dataset",
+            "s3://test-timdex-bucket/dataset/data/records",
         ],
         "promote-index-command": [
             "promote",
@@ -244,5 +241,4 @@ def test_generate_load_commands_unhandled_run_type(run_id):
         "2022-01-02",
         "not-supported-run-type",
         "run-abc-123",
-        "test-timdex-bucket",
     ) == {"failure": "Unexpected run-type: 'not-supported-run-type'"}

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,4 +1,4 @@
-# ruff: noqa: FBT003, PT011
+# ruff: noqa: FBT003
 
 import pytest
 
@@ -17,87 +17,6 @@ def test_verbosity_returns_true_if_true_string():
 
 def test_verbosity_returns_false_if_false_string():
     assert CONFIG.check_verbosity("Anything-but-true") is False
-
-
-def test_validate_input_missing_required_field_raises_error():
-    event = {
-        "next-step": "transform",
-        "run-type": "full",
-        "source": "testsource",
-    }
-    with pytest.raises(ValueError) as error:
-        CONFIG.validate_input(event)
-    assert "Input must include all required fields. Missing fields: ['run-date']" in str(
-        error.value
-    )
-
-
-def test_validate_input_with_invalid_next_step_raises_error():
-    event = {
-        "next-step": "wrong",
-        "run-date": "2022-01-02T12:13:14Z",
-        "run-type": "full",
-        "source": "testsource",
-    }
-    with pytest.raises(ValueError) as error:
-        CONFIG.validate_input(event)
-    assert (
-        "Input 'next-step' value must be one of: "
-        f"{CONFIG.VALID_STEPS}. Value provided was 'wrong'" in str(error.value)
-    )
-
-
-def test_validate_input_with_invalid_run_type_raises_error():
-    event = {
-        "next-step": "load",
-        "run-date": "2022-01-02",
-        "run-type": "wrong",
-        "source": "testsource",
-    }
-    with pytest.raises(ValueError) as error:
-        CONFIG.validate_input(event)
-    assert (
-        f"Input 'run-type' value must be one of: {CONFIG.VALID_RUN_TYPES}. "
-        "Value provided was 'wrong'" in str(error.value)
-    )
-
-
-def test_validate_input_with_missing_harvest_fields_raises_error():
-    event = {
-        "next-step": "extract",
-        "run-date": "2022-01-02:T12:13:14Z",
-        "run-type": "full",
-        "source": "testsource",
-        "oai-pmh-host": "https://example.com/oai",
-    }
-    with pytest.raises(ValueError) as error:
-        CONFIG.validate_input(event)
-    assert (
-        "Input must include all required harvest fields when starting with "
-        "harvest step. Missing fields: ['oai-metadata-format']" in str(error.value)
-    )
-
-
-def test_validate_input_with_all_required_fields_returns_none():
-    event = {
-        "next-step": "transform",
-        "run-date": "2022-01-02T12:13:14Z",
-        "run-type": "full",
-        "source": "testsource",
-    }
-    assert CONFIG.validate_input(event) is None
-
-
-def test_validate_input_with_all_required_harvest_fields_returns_none():
-    event = {
-        "next-step": "extract",
-        "run-date": "2022-01-02",
-        "run-type": "daily",
-        "source": "testsource",
-        "oai-pmh-host": "https://example.com/oai",
-        "oai-metadata-format": "oai_dc",
-    }
-    assert CONFIG.validate_input(event) is None
 
 
 def test_verify_env_missing_env_raises_error(monkeypatch):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -8,15 +8,15 @@ CONFIG = Config()
 
 
 def test_verbosity_returns_bool_if_bool():
-    assert CONFIG.check_verbosity(True) is True
+    assert CONFIG.get_verbose_flag(True) is True
 
 
 def test_verbosity_returns_true_if_true_string():
-    assert CONFIG.check_verbosity("True") is True
+    assert CONFIG.get_verbose_flag("True") is True
 
 
 def test_verbosity_returns_false_if_false_string():
-    assert CONFIG.check_verbosity("Anything-but-true") is False
+    assert CONFIG.get_verbose_flag("Anything-but-true") is False
 
 
 def test_verify_env_missing_env_raises_error(monkeypatch):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -2,19 +2,21 @@
 
 import pytest
 
-from lambdas import config
+from lambdas.config import Config
+
+CONFIG = Config()
 
 
 def test_verbosity_returns_bool_if_bool():
-    assert config.check_verbosity(True) is True
+    assert CONFIG.check_verbosity(True) is True
 
 
 def test_verbosity_returns_true_if_true_string():
-    assert config.check_verbosity("True") is True
+    assert CONFIG.check_verbosity("True") is True
 
 
 def test_verbosity_returns_false_if_false_string():
-    assert config.check_verbosity("Anything-but-true") is False
+    assert CONFIG.check_verbosity("Anything-but-true") is False
 
 
 def test_validate_input_missing_required_field_raises_error():
@@ -24,7 +26,7 @@ def test_validate_input_missing_required_field_raises_error():
         "source": "testsource",
     }
     with pytest.raises(ValueError) as error:
-        config.validate_input(event)
+        CONFIG.validate_input(event)
     assert "Input must include all required fields. Missing fields: ['run-date']" in str(
         error.value
     )
@@ -38,10 +40,10 @@ def test_validate_input_with_invalid_next_step_raises_error():
         "source": "testsource",
     }
     with pytest.raises(ValueError) as error:
-        config.validate_input(event)
+        CONFIG.validate_input(event)
     assert (
         "Input 'next-step' value must be one of: "
-        f"{config.VALID_STEPS}. Value provided was 'wrong'" in str(error.value)
+        f"{CONFIG.VALID_STEPS}. Value provided was 'wrong'" in str(error.value)
     )
 
 
@@ -53,9 +55,9 @@ def test_validate_input_with_invalid_run_type_raises_error():
         "source": "testsource",
     }
     with pytest.raises(ValueError) as error:
-        config.validate_input(event)
+        CONFIG.validate_input(event)
     assert (
-        f"Input 'run-type' value must be one of: {config.VALID_RUN_TYPES}. "
+        f"Input 'run-type' value must be one of: {CONFIG.VALID_RUN_TYPES}. "
         "Value provided was 'wrong'" in str(error.value)
     )
 
@@ -69,7 +71,7 @@ def test_validate_input_with_missing_harvest_fields_raises_error():
         "oai-pmh-host": "https://example.com/oai",
     }
     with pytest.raises(ValueError) as error:
-        config.validate_input(event)
+        CONFIG.validate_input(event)
     assert (
         "Input must include all required harvest fields when starting with "
         "harvest step. Missing fields: ['oai-metadata-format']" in str(error.value)
@@ -83,7 +85,7 @@ def test_validate_input_with_all_required_fields_returns_none():
         "run-type": "full",
         "source": "testsource",
     }
-    assert config.validate_input(event) is None
+    assert CONFIG.validate_input(event) is None
 
 
 def test_validate_input_with_all_required_harvest_fields_returns_none():
@@ -95,15 +97,17 @@ def test_validate_input_with_all_required_harvest_fields_returns_none():
         "oai-pmh-host": "https://example.com/oai",
         "oai-metadata-format": "oai_dc",
     }
-    assert config.validate_input(event) is None
+    assert CONFIG.validate_input(event) is None
 
 
 def test_verify_env_missing_env_raises_error(monkeypatch):
     monkeypatch.delenv("WORKSPACE", raising=False)
-    with pytest.raises(RuntimeError) as error:
-        config.verify_env()
-    assert "Required env variable WORKSPACE is not set" in str(error)
+    with pytest.raises(
+        OSError,
+        match="Missing required environment variables: WORKSPACE",
+    ):
+        CONFIG.check_required_env_vars()
 
 
 def test_verify_env_all_present_returns_none():
-    assert config.verify_env() is None
+    assert CONFIG.check_required_env_vars() is None

--- a/tests/test_format_input.py
+++ b/tests/test_format_input.py
@@ -61,7 +61,7 @@ def test_lambda_handler_with_next_step_transform_files_present(s3_client, run_ti
                     "transform-command": [
                         "--input-file=s3://test-timdex-bucket/testsource/"
                         "testsource-2022-01-02-daily-extracted-records-to-index.xml",
-                        "--output-location=s3://test-timdex-bucket/dataset",
+                        "--output-location=s3://test-timdex-bucket/dataset/data/records",
                         "--source=testsource",
                         "--run-id=run-abc-123",
                         f"--run-timestamp={run_timestamp}",
@@ -94,7 +94,7 @@ def test_lambda_handler_with_next_step_transform_alma_files_present(run_timestam
                     "transform-command": [
                         "--input-file=s3://test-timdex-bucket/alma/"
                         "alma-2022-09-12-daily-extracted-records-to-delete.xml",
-                        "--output-location=s3://test-timdex-bucket/dataset",
+                        "--output-location=s3://test-timdex-bucket/dataset/data/records",
                         "--source=alma",
                         "--run-id=run-abc-123",
                         f"--run-timestamp={run_timestamp}",
@@ -104,7 +104,7 @@ def test_lambda_handler_with_next_step_transform_alma_files_present(run_timestam
                     "transform-command": [
                         "--input-file=s3://test-timdex-bucket/alma/"
                         "alma-2022-09-12-daily-extracted-records-to-index_01.xml",
-                        "--output-location=s3://test-timdex-bucket/dataset",
+                        "--output-location=s3://test-timdex-bucket/dataset/data/records",
                         "--source=alma",
                         "--run-id=run-abc-123",
                         f"--run-timestamp={run_timestamp}",
@@ -114,7 +114,7 @@ def test_lambda_handler_with_next_step_transform_alma_files_present(run_timestam
                     "transform-command": [
                         "--input-file=s3://test-timdex-bucket/alma/"
                         "alma-2022-09-12-daily-extracted-records-to-index_02.xml",
-                        "--output-location=s3://test-timdex-bucket/dataset",
+                        "--output-location=s3://test-timdex-bucket/dataset/data/records",
                         "--source=alma",
                         "--run-id=run-abc-123",
                         f"--run-timestamp={run_timestamp}",
@@ -160,7 +160,7 @@ def test_lambda_handler_with_next_step_transform_auto_generated_timestamp(s3_cli
                     "transform-command": [
                         "--input-file=s3://test-timdex-bucket/testsource/"
                         "testsource-2022-01-02-daily-extracted-records-to-index.xml",
-                        "--output-location=s3://test-timdex-bucket/dataset",
+                        "--output-location=s3://test-timdex-bucket/dataset/data/records",
                         "--source=testsource",
                         "--run-id=run-abc-123",
                         "--run-timestamp=2025-06-18T12:34:56.789000",
@@ -253,7 +253,7 @@ def test_lambda_handler_with_next_step_load_files_present(s3_client):
                 "run-abc-123",
                 "--source",
                 "testsource",
-                "s3://test-timdex-bucket/dataset",
+                "s3://test-timdex-bucket/dataset/data/records",
             ]
         },
     }

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -9,6 +9,87 @@ from lambdas.config import Config
 CONFIG = Config()
 
 
+def test_validate_input_missing_required_field_raises_error():
+    event = {
+        "next-step": "transform",
+        "run-type": "full",
+        "source": "testsource",
+    }
+    with pytest.raises(ValueError) as error:
+        helpers.validate_input(event)
+    assert "Input must include all required fields. Missing fields: ['run-date']" in str(
+        error.value
+    )
+
+
+def test_validate_input_with_invalid_next_step_raises_error():
+    event = {
+        "next-step": "wrong",
+        "run-date": "2022-01-02T12:13:14Z",
+        "run-type": "full",
+        "source": "testsource",
+    }
+    with pytest.raises(ValueError) as error:
+        helpers.validate_input(event)
+    assert (
+        "Input 'next-step' value must be one of: "
+        f"{CONFIG.VALID_STEPS}. Value provided was 'wrong'" in str(error.value)
+    )
+
+
+def test_validate_input_with_invalid_run_type_raises_error():
+    event = {
+        "next-step": "load",
+        "run-date": "2022-01-02",
+        "run-type": "wrong",
+        "source": "testsource",
+    }
+    with pytest.raises(ValueError) as error:
+        helpers.validate_input(event)
+    assert (
+        f"Input 'run-type' value must be one of: {CONFIG.VALID_RUN_TYPES}. "
+        "Value provided was 'wrong'" in str(error.value)
+    )
+
+
+def test_validate_input_with_missing_harvest_fields_raises_error():
+    event = {
+        "next-step": "extract",
+        "run-date": "2022-01-02:T12:13:14Z",
+        "run-type": "full",
+        "source": "testsource",
+        "oai-pmh-host": "https://example.com/oai",
+    }
+    with pytest.raises(ValueError) as error:
+        helpers.validate_input(event)
+    assert (
+        "Input must include all required harvest fields when starting with "
+        "harvest step. Missing fields: ['oai-metadata-format']" in str(error.value)
+    )
+
+
+def test_validate_input_with_all_required_fields_returns_none():
+    event = {
+        "next-step": "transform",
+        "run-date": "2022-01-02T12:13:14Z",
+        "run-type": "full",
+        "source": "testsource",
+    }
+    assert helpers.validate_input(event) is None
+
+
+def test_validate_input_with_all_required_harvest_fields_returns_none():
+    event = {
+        "next-step": "extract",
+        "run-date": "2022-01-02",
+        "run-type": "daily",
+        "source": "testsource",
+        "oai-pmh-host": "https://example.com/oai",
+        "oai-metadata-format": "oai_dc",
+    }
+    assert helpers.validate_input(event) is None
+
+
 def test_format_run_date_valid_run_date_string():
     assert helpers.format_run_date("2022-01-02T12:13:14Z") == "2022-01-02"
 

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -3,7 +3,10 @@
 import pytest
 from freezegun import freeze_time
 
-from lambdas import config, errors, helpers
+from lambdas import errors, helpers
+from lambdas.config import Config
+
+CONFIG = Config()
 
 
 def test_format_run_date_valid_run_date_string():
@@ -15,7 +18,7 @@ def test_format_run_date_invalid_run_date_string_raises_error():
         helpers.format_run_date("20220102")
     assert (
         "Input 'run-date' value must be one of the following date string formats: "
-        f"{config.VALID_DATE_FORMATS}. Value provided was '20220102'"
+        f"{CONFIG.VALID_DATE_FORMATS}. Value provided was '20220102'"
     ) in str(error.value)
 
 


### PR DESCRIPTION
### Purpose and background context

This PR updates the pipeline lambdas to provide a new location for Transmogrifier to **write** to, and TIM to **read** from, in the ETL dataset in S3.

This work is in support of the [ADR that strives to add a new metadata layer to the TIMDEX ETL dataset](https://mitlibraries.atlassian.net/wiki/spaces/D/pages/4700962824/Managed+ETL+Dataset+Metadata).  As luck would have it, this is the _only_ place that defines where data is write/read from in the ETL dataset, making it a single place to update.

It's proposed that moving this data out of the "dataset" root and into a more precise `/data/records` location is worth the effort, even if we decide to not move forward with the ADR.

A quick update would have been to change the hardcoded `/dateset` in code to `/dataset/data/records` which would have basically had the same effect.  But, it seemed like a good time to make some updates in this project that have been floating around for a bit.

Updates include:
   - move configurations into a `Config` class that matches other applications
   - move any `os.environ[]` code blocks out of code and into the new `Config` class
   - allow the `Config` class to drive the new dataset location

It's advised to review commit-by-commit.  

  **NOTE:** As noted in the final commit, we benefit from the ETL pipeline design in that making this change immediately will not negatively effect previous writes to the dataset.  

Said another way, if we deploy this now, Transmogrifier will write to `/dataset/data/records` in S3 for an ETL run, and TIM will read from that location for the same ETL run.  _Previous_ ETL run data will remain at a different location in the dataset, but another ticket in https://mitlibraries.atlassian.net/browse/TIMX-518 will perform that manual migration work.

### How can a reviewer manually see the effects of these changes?

Not easily reproducible locally until we introduce AWS SAM to this lambda for quicker local testing 😄.  

But, [a test StepFunction run was performed in Dev](https://222053980223-lritm6hn.us-east-1.console.aws.amazon.com/states/home?region=us-east-1#/v2/executions/details/arn:aws:states:us-east-1:222053980223:execution:timdex-ingest-dev:99394b24-ae09-4a87-8bf2-69f9362c4a9d) that demonstrates it working.

Flying in the output from the pipeline lambda that provides commands to Transmog:

```json
{
  "run-date": "2025-07-24",
  "run-type": "full",
  "source": "libguides",
  "verbose": true,
  "next-step": "load",
  "transform": {
    "files-to-transform": [
      {
        "transform-command": [
          "--input-file=s3://timdex-extract-dev-222053980223/libguides/libguides-2025-07-24-full-extracted-records-to-index.xml",
          "--output-location=s3://timdex-extract-dev-222053980223/dataset/data/records",  <--------------------
          "--source=libguides",
          "--run-id=99394b24-ae09-4a87-8bf2-69f9362c4a9d",
          "--run-timestamp=2025-07-24T18:24:49.207444+00:00"
        ]
      }
    ]
  }
}
```

and to TIM:

```json
{
  "run-date": "2025-07-24",
  "run-type": "full",
  "source": "libguides",
  "verbose": true,
  "load": {
    "create-index-command": [
      "create",
      "--index",
      "libguides-2025-07-24t18-25-44"
    ],
    "bulk-update-command": [
      "bulk-update",
      "--run-date",
      "2025-07-24",
      "--run-id",
      "99394b24-ae09-4a87-8bf2-69f9362c4a9d",
      "--index",
      "libguides-2025-07-24t18-25-44",
      "s3://timdex-extract-dev-222053980223/dataset/data/records"  <--------------------
    ],
    "promote-index-command": [
      "promote",
      "--index",
      "libguides-2025-07-24t18-25-44"
    ]
  }
}
```

Where in both we can see the new dataset location of `/dataset/data/records`.

This also demonstrates how this update will result in a new `/data` folder in S3, that happily sits alongside previous ETL runs at the root of the `/dataset` folder:

<img width="291" height="446" alt="Screenshot 2025-07-24 at 4 26 27 PM" src="https://github.com/user-attachments/assets/458d4327-b69e-4f2e-a4da-ad09297e50fa" />

### Includes new or updated dependencies?
YES

### Changes expectations for external applications?
YES: sort of!  Both Transmog and TIM will get new dataset locations to write/read from, but they were dynamic CLI arguments already.

### What are the relevant tickets?
- https://mitlibraries.atlassian.net/browse/TIMX-515
- https://mitlibraries.atlassian.net/browse/TIMX-518
- https://mitlibraries.atlassian.net/browse/TIMX-521
