### PR TITLE
USE 140 - embeddings create and index flow control

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -139,3 +139,5 @@ dmypy.json
 # SAM
 .aws-sam/
 tests/sam/env.json
+
+output/

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -26,20 +26,20 @@
         },
         "boto3": {
             "hashes": [
-                "sha256:4251bbac90e4a190680439973d9e9ed851e50292c10cd063c8bf0c365410ffe1",
-                "sha256:edbfbfbadd419e65888166dd044786d4b731cf60abeb2301b73e775e154d7c5e"
+                "sha256:a4eb51105c8c5d7b2bc2a9e2316e69baf69a55611275b9f189c0cf59f1aae171",
+                "sha256:e0ff6f2747bfdec63405b35ea185a7aea35239c3f4fe99e4d29368a6de9c4a84"
             ],
             "index": "pypi",
             "markers": "python_version >= '3.9'",
-            "version": "==1.42.35"
+            "version": "==1.42.36"
         },
         "botocore": {
             "hashes": [
-                "sha256:40a6e0f16afe9e5d42e956f0b6d909869793fadb21780e409063601fc3d094b8",
-                "sha256:b89f527987691abbd1374c4116cc2711471ce48e6da502db17e92b17b2af8d47"
+                "sha256:2cfae4c482e5e87bd835ab4289b711490c161ba57e852c06b65a03e7c25e08eb",
+                "sha256:2ebd89cc75927944e2cee51b7adce749f38e0cb269a758a6464a27f8bcca65fb"
             ],
             "markers": "python_version >= '3.9'",
-            "version": "==1.42.35"
+            "version": "==1.42.36"
         },
         "duckdb": {
             "hashes": [
@@ -604,38 +604,38 @@
         },
         "boto3": {
             "hashes": [
-                "sha256:4251bbac90e4a190680439973d9e9ed851e50292c10cd063c8bf0c365410ffe1",
-                "sha256:edbfbfbadd419e65888166dd044786d4b731cf60abeb2301b73e775e154d7c5e"
+                "sha256:a4eb51105c8c5d7b2bc2a9e2316e69baf69a55611275b9f189c0cf59f1aae171",
+                "sha256:e0ff6f2747bfdec63405b35ea185a7aea35239c3f4fe99e4d29368a6de9c4a84"
             ],
             "markers": "python_version >= '3.9'",
-            "version": "==1.42.35"
+            "version": "==1.42.36"
         },
         "boto3-stubs": {
             "extras": [
                 "essential"
             ],
             "hashes": [
-                "sha256:20aab5dee59d4d0a95152bd7be584faafb9f6bcf146ffff3cd6055f71d006d6a",
-                "sha256:ae5a841e4d9d7afee5637e9bc90244a6f0515e494280926fe74fe08c113672ec"
+                "sha256:02904609e0d0aefc7f9c330b4312a5a2bff3789b03a1ba30e7cb8acb11c616a5",
+                "sha256:0c367fbe305d9c76983989eea81e4ee2f43b992f553fdb8a0de67908877c9b00"
             ],
             "markers": "python_version >= '3.9'",
-            "version": "==1.42.35"
+            "version": "==1.42.36"
         },
         "botocore": {
             "hashes": [
-                "sha256:40a6e0f16afe9e5d42e956f0b6d909869793fadb21780e409063601fc3d094b8",
-                "sha256:b89f527987691abbd1374c4116cc2711471ce48e6da502db17e92b17b2af8d47"
+                "sha256:2cfae4c482e5e87bd835ab4289b711490c161ba57e852c06b65a03e7c25e08eb",
+                "sha256:2ebd89cc75927944e2cee51b7adce749f38e0cb269a758a6464a27f8bcca65fb"
             ],
             "markers": "python_version >= '3.9'",
-            "version": "==1.42.35"
+            "version": "==1.42.36"
         },
         "botocore-stubs": {
             "hashes": [
-                "sha256:375cf9534f6f2a35bd2c9e7076e88fb49fb7d589c5aac129db6a9ffc13561cad",
-                "sha256:4d3389aa0a09c96f9aaabc2fb079768da0b2940430e39c270c992e1e36f8a54c"
+                "sha256:15bed118ffc4d413a75822c7182af9a9e9989ccdf5d9528bc7b98bb03edf2971",
+                "sha256:b3e7505f411b26b303ed24835ac29a7aa7ec2aedcead92e4665d1b4566c396bd"
             ],
             "markers": "python_version >= '3.9'",
-            "version": "==1.42.35"
+            "version": "==1.42.36"
         },
         "cachecontrol": {
             "extras": [
@@ -982,63 +982,58 @@
         },
         "cryptography": {
             "hashes": [
-                "sha256:00a5e7e87938e5ff9ff5447ab086a5706a957137e6e433841e9d24f38a065217",
-                "sha256:01ca9ff2885f3acc98c29f1860552e37f6d7c7d013d7334ff2a9de43a449315d",
-                "sha256:09859af8466b69bc3c27bdf4f5d84a665e0f7ab5088412e9e2ec49758eca5cbc",
-                "sha256:0abf1ffd6e57c67e92af68330d05760b7b7efb243aab8377e583284dbab72c71",
-                "sha256:1000713389b75c449a6e979ffc7dcc8ac90b437048766cef052d4d30b8220971",
-                "sha256:109d4ddfadf17e8e7779c39f9b18111a09efb969a301a31e987416a0191ed93a",
-                "sha256:10b01676fc208c3e6feeb25a8b83d81767e8059e1fe86e1dc62d10a3018fa926",
-                "sha256:10ca84c4668d066a9878890047f03546f3ae0a6b8b39b697457b7757aaf18dbc",
-                "sha256:15ab9b093e8f09daab0f2159bb7e47532596075139dd74365da52ecc9cb46c5d",
-                "sha256:191bb60a7be5e6f54e30ba16fdfae78ad3a342a0599eb4193ba88e3f3d6e185b",
-                "sha256:22d7e97932f511d6b0b04f2bfd818d73dcd5928db509460aaf48384778eb6d20",
-                "sha256:23b1a8f26e43f47ceb6d6a43115f33a5a37d57df4ea0ca295b780ae8546e8044",
-                "sha256:36e627112085bb3b81b19fed209c05ce2a52ee8b15d161b7c643a7d5a88491f3",
-                "sha256:39b6755623145ad5eff1dab323f4eae2a32a77a7abef2c5089a04a3d04366715",
-                "sha256:3b51b8ca4f1c6453d8829e1eb7299499ca7f313900dd4d89a24b8b87c0a780d4",
-                "sha256:402b58fc32614f00980b66d6e56a5b4118e6cb362ae8f3fda141ba4689bd4506",
-                "sha256:416260257577718c05135c55958b674000baef9a1c7d9e8f306ec60d71db850f",
-                "sha256:46acf53b40ea38f9c6c229599a4a13f0d46a6c3fa9ef19fc1a124d62e338dfa0",
-                "sha256:4b7387121ac7d15e550f5cb4a43aef2559ed759c35df7336c402bb8275ac9683",
-                "sha256:50fc3343ac490c6b08c0cf0d704e881d0d660be923fd3076db3e932007e726e3",
-                "sha256:516ea134e703e9fe26bcd1277a4b59ad30586ea90c365a87781d7887a646fe21",
-                "sha256:549e234ff32571b1f4076ac269fcce7a808d3bf98b76c8dd560e42dbc66d7d91",
-                "sha256:5d7f93296ee28f68447397bf5198428c9aeeab45705a55d53a6343455dcb2c3c",
-                "sha256:5ecfccd2329e37e9b7112a888e76d9feca2347f12f37918facbb893d7bb88ee8",
-                "sha256:6276eb85ef938dc035d59b87c8a7dc559a232f954962520137529d77b18ff1df",
-                "sha256:6b5063083824e5509fdba180721d55909ffacccc8adbec85268b48439423d78c",
-                "sha256:6eae65d4c3d33da080cff9c4ab1f711b15c1d9760809dad6ea763f3812d254cb",
-                "sha256:6f61efb26e76c45c4a227835ddeae96d83624fb0d29eb5df5b96e14ed1a0afb7",
-                "sha256:71e842ec9bc7abf543b47cf86b9a743baa95f4677d22baa4c7d5c69e49e9bc04",
-                "sha256:760f83faa07f8b64e9c33fc963d790a2edb24efb479e3520c14a45741cd9b2db",
-                "sha256:78a97cf6a8839a48c49271cdcbd5cf37ca2c1d6b7fdd86cc864f302b5e9bf459",
-                "sha256:7ce938a99998ed3c8aa7e7272dca1a610401ede816d36d0693907d863b10d9ea",
-                "sha256:8a6e050cb6164d3f830453754094c086ff2d0b2f3a897a1d9820f6139a1f0914",
-                "sha256:9394673a9f4de09e28b5356e7fff97d778f8abad85c9d5ac4a4b7e25a0de7717",
-                "sha256:94cd0549accc38d1494e1f8de71eca837d0509d0d44bf11d158524b0e12cebf9",
-                "sha256:a04bee9ab6a4da801eb9b51f1b708a1b5b5c9eb48c03f74198464c66f0d344ac",
-                "sha256:a23582810fedb8c0bc47524558fb6c56aac3fc252cb306072fd2815da2a47c32",
-                "sha256:a2c0cd47381a3229c403062f764160d57d4d175e022c1df84e168c6251a22eec",
-                "sha256:a8b17438104fed022ce745b362294d9ce35b4c2e45c1d958ad4a4b019285f4a1",
-                "sha256:a9a3008438615669153eb86b26b61e09993921ebdd75385ddd748702c5adfddb",
-                "sha256:b02cf04496f6576afffef5ddd04a0cb7d49cf6be16a9059d793a30b035f6b6ac",
-                "sha256:b419ae593c86b87014b9be7396b385491ad7f320bde96826d0dd174459e54665",
-                "sha256:c0a7bb1a68a5d3471880e264621346c48665b3bf1c3759d682fc0864c540bd9e",
-                "sha256:c70cc23f12726be8f8bc72e41d5065d77e4515efae3690326764ea1b07845cfb",
-                "sha256:c8daeb2d2174beb4575b77482320303f3d39b8e81153da4f0fb08eb5fe86a6c5",
-                "sha256:cb3d760a6117f621261d662bccc8ef5bc32ca673e037c83fbe565324f5c46936",
-                "sha256:d55f3dffadd674514ad19451161118fd010988540cee43d8bc20675e775925de",
-                "sha256:d89c3468de4cdc4f08a57e214384d0471911a3830fcdaf7a8cc587e42a866372",
-                "sha256:db391fa7c66df6762ee3f00c95a89e6d428f4d60e7abc8328f4fe155b5ac6e54",
-                "sha256:dfb781ff7eaa91a6f7fd41776ec37c5853c795d3b358d4896fdbb5df168af422",
-                "sha256:e5bf0ed4490068a2e72ac03d786693adeb909981cc596425d09032d372bcc849",
-                "sha256:e7aec276d68421f9574040c26e2a7c3771060bc0cff408bae1dcb19d3ab1e63c",
-                "sha256:ef639cb3372f69ec44915fafcd6698b6cc78fbe0c2ea41be867f6ed612811963",
-                "sha256:f260d0d41e9b4da1ed1e0f1ce571f97fe370b152ab18778e9e8f67d6af432018"
+                "sha256:01df4f50f314fbe7009f54046e908d1754f19d0c6d3070df1e6268c5a4af09fa",
+                "sha256:0563655cb3c6d05fb2afe693340bc050c30f9f34e15763361cf08e94749401fc",
+                "sha256:078e5f06bd2fa5aea5a324f2a09f914b1484f1d0c2a4d6a8a28c74e72f65f2da",
+                "sha256:0a9ad24359fee86f131836a9ac3bffc9329e956624a2d379b613f8f8abaf5255",
+                "sha256:2067461c80271f422ee7bdbe79b9b4be54a5162e90345f86a23445a0cf3fd8a2",
+                "sha256:281526e865ed4166009e235afadf3a4c4cba6056f99336a99efba65336fd5485",
+                "sha256:2d08bc22efd73e8854b0b7caff402d735b354862f1145d7be3b9c0f740fef6a0",
+                "sha256:3c268a3490df22270955966ba236d6bc4a8f9b6e4ffddb78aac535f1a5ea471d",
+                "sha256:3d425eacbc9aceafd2cb429e42f4e5d5633c6f873f5e567077043ef1b9bbf616",
+                "sha256:44cc0675b27cadb71bdbb96099cca1fa051cd11d2ade09e5cd3a2edb929ed947",
+                "sha256:47bcd19517e6389132f76e2d5303ded6cf3f78903da2158a671be8de024f4cd0",
+                "sha256:485e2b65d25ec0d901bca7bcae0f53b00133bf3173916d8e421f6fddde103908",
+                "sha256:5aa3e463596b0087b3da0dbe2b2487e9fc261d25da85754e30e3b40637d61f81",
+                "sha256:5f14fba5bf6f4390d7ff8f086c566454bff0411f6d8aa7af79c88b6f9267aecc",
+                "sha256:62217ba44bf81b30abaeda1488686a04a702a261e26f87db51ff61d9d3510abd",
+                "sha256:6225d3ebe26a55dbc8ead5ad1265c0403552a63336499564675b29eb3184c09b",
+                "sha256:6bb5157bf6a350e5b28aee23beb2d84ae6f5be390b2f8ee7ea179cda077e1019",
+                "sha256:728fedc529efc1439eb6107b677f7f7558adab4553ef8669f0d02d42d7b959a7",
+                "sha256:766330cce7416c92b5e90c3bb71b1b79521760cdcfc3a6a1a182d4c9fab23d2b",
+                "sha256:812815182f6a0c1d49a37893a303b44eaac827d7f0d582cecfc81b6427f22973",
+                "sha256:829c2b12bbc5428ab02d6b7f7e9bbfd53e33efd6672d21341f2177470171ad8b",
+                "sha256:82a62483daf20b8134f6e92898da70d04d0ef9a75829d732ea1018678185f4f5",
+                "sha256:8a15fb869670efa8f83cbffbc8753c1abf236883225aed74cd179b720ac9ec80",
+                "sha256:8bf75b0259e87fa70bddc0b8b4078b76e7fd512fd9afae6c1193bcf440a4dbef",
+                "sha256:91627ebf691d1ea3976a031b61fb7bac1ccd745afa03602275dda443e11c8de0",
+                "sha256:93d8291da8d71024379ab2cb0b5c57915300155ad42e07f76bea6ad838d7e59b",
+                "sha256:9b34d8ba84454641a6bf4d6762d15847ecbd85c1316c0a7984e6e4e9f748ec2e",
+                "sha256:9b4d17bc7bd7cdd98e3af40b441feaea4c68225e2eb2341026c84511ad246c0c",
+                "sha256:9c2da296c8d3415b93e6053f5a728649a87a48ce084a9aaf51d6e46c87c7f2d2",
+                "sha256:a05177ff6296644ef2876fce50518dffb5bcdf903c85250974fc8bc85d54c0af",
+                "sha256:a90e43e3ef65e6dcf969dfe3bb40cbf5aef0d523dff95bfa24256be172a845f4",
+                "sha256:a9556ba711f7c23f77b151d5798f3ac44a13455cc68db7697a1096e6d0563cab",
+                "sha256:b1de0ebf7587f28f9190b9cb526e901bf448c9e6a99655d2b07fff60e8212a82",
+                "sha256:be8c01a7d5a55f9a47d1888162b76c8f49d62b234d88f0ff91a9fbebe32ffbc3",
+                "sha256:bfd019f60f8abc2ed1b9be4ddc21cfef059c841d86d710bb69909a688cbb8f59",
+                "sha256:c236a44acfb610e70f6b3e1c3ca20ff24459659231ef2f8c48e879e2d32b73da",
+                "sha256:c411f16275b0dea722d76544a61d6421e2cc829ad76eec79280dbdc9ddf50061",
+                "sha256:c92010b58a51196a5f41c3795190203ac52edfd5dc3ff99149b4659eba9d2085",
+                "sha256:d5a45ddc256f492ce42a4e35879c5e5528c09cd9ad12420828c972951d8e016b",
+                "sha256:daa392191f626d50f1b136c9b4cf08af69ca8279d110ea24f5c2700054d2e263",
+                "sha256:dc1272e25ef673efe72f2096e92ae39dea1a1a450dd44918b15351f72c5a168e",
+                "sha256:dce1e4f068f03008da7fa51cc7abc6ddc5e5de3e3d1550334eaf8393982a5829",
+                "sha256:dd5aba870a2c40f87a3af043e0dee7d9eb02d4aff88a797b48f2b43eff8c3ab4",
+                "sha256:de0f5f4ec8711ebc555f54735d4c673fc34b65c44283895f1a08c2b49d2fd99c",
+                "sha256:df4a817fa7138dd0c96c8c8c20f04b8aaa1fac3bbf610913dcad8ea82e1bfd3f",
+                "sha256:e07ea39c5b048e085f15923511d8121e4a9dc45cee4e3b970ca4f0d338f23095",
+                "sha256:eeeb2e33d8dbcccc34d64651f00a98cb41b2dc69cef866771a5717e6734dfa32",
+                "sha256:fa0900b9ef9c49728887d1576fd8d9e7e3ea872fa9b25ef9b64888adc434e976",
+                "sha256:fdc3daab53b212472f1524d070735b2f0c214239df131903bae1d598016fa822"
             ],
             "markers": "python_version >= '3.8' and python_full_version not in '3.9.0, 3.9.1'",
-            "version": "==46.0.3"
+            "version": "==46.0.4"
         },
         "cyclonedx-python-lib": {
             "hashes": [
@@ -1510,11 +1505,11 @@
         },
         "mypy-boto3-ec2": {
             "hashes": [
-                "sha256:2d17f1de30cc95dbefeabc091aca1eb32ba4fe33dc141fc1383bcdf9e0c03f62",
-                "sha256:ba25087ee6dd61347424be1f2cb02b9cbf5f1cc737e49b69070b9dda95b71c4c"
+                "sha256:0468a5fe39eb7d45c6e0af4aeacf25663f251acfe0b6c227effdbc2e630beec6",
+                "sha256:7ea0cd827ed77d60c0c6355b1752ac683898de6f19c2db942c7a87b5b1c483bb"
             ],
             "markers": "python_version >= '3.9'",
-            "version": "==1.42.35"
+            "version": "==1.42.36"
         },
         "mypy-boto3-lambda": {
             "hashes": [

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Takes input JSON (usually from EventBridge although it can be passed to a manual
 
 #### Required
 
-- `next-step`: The next step of the pipeline to be performed, must be one of `["extract", "transform", "load"]`. Determines which task run commands will be generated as output from the format lambda.
+- `next-step`: The next step of the pipeline to be performed. Determines which task run commands will be generated as output from the format lambda.
 - `run-date`: Must be in one of the formats ["yyyy-mm-dd", "yyyy-mm-ddThh:mm:ssZ"]. The provided date is used in the input/output file naming scheme for all steps of the pipeline.
 - `run-type`: Must be one of `["full", "daily"]`. The provided run type is used in the input/output file naming scheme for all steps of the pipeline. It also determines logic for both the OAI-PMH harvest and load commands as follows:
   - `full`: Perform a full harvest of all records from the provided `oai-pmh-host`. During load, create a new OpenSearch index, load all records into it, and then promote the new index.

--- a/lambdas/commands.py
+++ b/lambdas/commands.py
@@ -1,4 +1,5 @@
 import logging
+import uuid
 from typing import TYPE_CHECKING
 
 from lambdas import helpers
@@ -10,6 +11,8 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 CONFIG = Config()
+
+GPU_RECORD_COUNT_THRESHOLD = 500
 
 
 def generate_extract_command(input_payload: "InputPayload") -> dict:
@@ -148,3 +151,45 @@ def generate_load_commands(input_payload: "InputPayload") -> dict:
         }
 
     return {"failure": f"Unexpected run-type: '{input_payload.run_type}'"}
+
+
+def generate_embeddings_create_command(
+    input_payload: "InputPayload",
+    record_count: int,
+) -> dict:
+    """Generate AWS Batch job parameters for creating embeddings.
+
+    Determines compute environment based on record count:
+    - cpu (ECS Fargate) for < 500 records
+    - gpu-spot (EC2 Spot) for >= 500 records
+    """
+    job_compute_env = "gpu-spot" if record_count >= GPU_RECORD_COUNT_THRESHOLD else "cpu"
+
+    return {
+        "create": {
+            "job_name": f"create-embeddings-{job_compute_env}-{uuid.uuid4()}",
+            "job_compute_env": job_compute_env,
+            "command": [
+                "--verbose",
+                "create-embeddings",
+                "--strategy=full_record",
+                f"--dataset-location={CONFIG.s3_timdex_dataset_location}",
+                f"--run-id={input_payload.run_id}",
+            ],
+        }
+    }
+
+
+def generate_embeddings_load_command(input_payload: "InputPayload") -> dict:
+    """Generate TIM command to update documents with embeddings."""
+    return {
+        "load": {
+            "bulk-update-embeddings-command": [
+                "--verbose",
+                "bulk-update-embeddings",
+                f"--source={input_payload.source}",
+                f"--run-id={input_payload.run_id}",
+                CONFIG.s3_timdex_dataset_location,
+            ],
+        }
+    }

--- a/lambdas/config.py
+++ b/lambdas/config.py
@@ -42,7 +42,8 @@ class Config:
     SOURCE_EXCLUSION_LISTS: ClassVar = {"libguides": "/config/libguides/exclusions.csv"}
     VALID_DATE_FORMATS = ("%Y-%m-%d", "%Y-%m-%dT%H:%M:%SZ")
     VALID_RUN_TYPES = ("full", "daily")
-    VALID_STEPS = ("extract", "transform", "load")
+    VALID_STEPS = ("extract", "transform", "load", "embeddings-create", "embeddings-load")
+    SKIP_EMBEDDINGS_SOURCES = ("alma", "gisogm")
 
     def __getattr__(self, name: str) -> Any:  # noqa: ANN401
         """Provide dot notation access to configurations and env vars on this class."""

--- a/lambdas/format_input.py
+++ b/lambdas/format_input.py
@@ -1,9 +1,13 @@
+# ruff: noqa: S608
+
 import json
 import logging
 import uuid
 from dataclasses import asdict, dataclass
 from datetime import UTC, datetime
 from typing import Literal
+
+from timdex_dataset_api.dataset import TIMDEXDataset  # type: ignore[import-untyped]
 
 from lambdas import alma_prep, commands, errors, helpers
 from lambdas.config import Config, configure_logger
@@ -12,13 +16,22 @@ logger = logging.getLogger(__name__)
 
 CONFIG = Config()
 
-type NextStep = Literal["extract", "transform", "load", "exit-ok", "exit-error", "end"]
+type NextStep = Literal[
+    "extract",
+    "transform",
+    "load",
+    "embeddings-create",
+    "embeddings-load",
+    "exit-ok",
+    "exit-error",
+    "end",
+]
 
 
 @dataclass
 class InputPayload:
     run_date: str
-    run_type: str
+    run_type: Literal["daily", "full"]
     source: str
     next_step: NextStep
     run_id: str
@@ -118,12 +131,14 @@ class ResultPayload:
     next_step: NextStep
     run_date: str
     run_type: str
+    run_id: str
     source: str
     verbose: bool = True
     harvester_type: str | None = None
     extract: dict | None = None
     transform: dict | None = None
     load: dict | None = None
+    embeddings: dict | None = None
     message: str | None = None
 
     @classmethod
@@ -132,6 +147,7 @@ class ResultPayload:
             next_step=input_payload.next_step,
             run_date=input_payload.run_date,
             run_type=input_payload.run_type,
+            run_id=input_payload.run_id,
             source=input_payload.source,
             verbose=input_payload.verbose,
         )
@@ -154,6 +170,10 @@ def lambda_handler(event: dict, _context: dict) -> dict:
         result = handle_transform(input_payload, result)
     elif input_payload.next_step == "load":
         result = handle_load(input_payload, result)
+    elif input_payload.next_step == "embeddings-create":
+        result = handle_embeddings_create(input_payload, result)
+    elif input_payload.next_step == "embeddings-load":
+        result = handle_embeddings_load(input_payload, result)
     else:
         raise ValueError(f"'next-step' not supported: '{input_payload.next_step}'")
 
@@ -213,7 +233,7 @@ def handle_transform(input_payload: InputPayload, result: ResultPayload) -> Resu
 
 
 def handle_load(input_payload: InputPayload, result: ResultPayload) -> ResultPayload:
-    result.next_step = "end"
+    result.next_step = "embeddings-create"
     if not helpers.dataset_records_exist_for_run(input_payload.run_id):
         result.next_step = "exit-ok"
         message = (
@@ -224,4 +244,102 @@ def handle_load(input_payload: InputPayload, result: ResultPayload) -> ResultPay
         result.message = message
         return result
     result.load = commands.generate_load_commands(input_payload)
+    return result
+
+
+def handle_embeddings_create(
+    input_payload: InputPayload, result: ResultPayload
+) -> ResultPayload:
+    """Analyze ETL run and prepare parameters for AWS Batch job to create embeddings.
+
+    There are currently three compute environments we can create embeddings in:
+        - ECS Fargate - "cpu"
+        - EC2 - "gpu"
+        - EC2 Spot Instances - "gpu-spot"
+
+    This lambda handler is responsible for analyzing the size and shape of the ETL run,
+    and determining which AWS Batch compute environment is most appropriate.
+
+    We do not create embeddings for all sources.  Those we skip are configured in
+    CONFIG.SKIP_EMBEDDINGS_SOURCES.
+
+    Additionally, at this time, we do not have a scenario or code path that would
+    utilize the "gpu" compute environment, only "gpu-spot".  This is mostly because we
+    don't require an immediate turnaround for embeddings creation; when the job size
+    calls for a GPU, we have the luxury of waiting for a spot instance.
+    """
+    result.next_step = "embeddings-load"
+
+    if input_payload.source in CONFIG.SKIP_EMBEDDINGS_SOURCES:
+        result.next_step = "exit-ok"
+        result.message = (
+            f"Not currently creating embeddings for source '{input_payload.source}'"
+        )
+        return result
+
+    # retrieve records count for run
+    td = TIMDEXDataset(location=CONFIG.s3_timdex_dataset_location)
+    record_count = td.metadata.conn.query(f"""
+        select count(*)
+        from metadata.records
+        where run_id = '{input_payload.run_id}'
+        and action in ('index')
+        """).fetchone()[0]
+
+    # exit early if no records to create embeddings for
+    if record_count == 0:
+        result.next_step = "exit-ok"
+        result.message = f"No embeddable records found for run '{input_payload.run_id}'."
+        return result
+
+    job_compute_env = (
+        "gpu-spot" if record_count >= commands.GPU_RECORD_COUNT_THRESHOLD else "cpu"
+    )
+    logger.info(
+        f"ETL run '{input_payload.run_id}' had {record_count} records indexed, "
+        f"recommending '{job_compute_env}' compute env."
+    )
+
+    result.embeddings = commands.generate_embeddings_create_command(
+        input_payload, record_count
+    )
+    return result
+
+
+def handle_embeddings_load(
+    input_payload: InputPayload, result: ResultPayload
+) -> ResultPayload:
+    """Prepare TIM command to update documents in Opensearch with embeddings.
+
+    We do not create embeddings for all sources.  Those we skip are configured in
+    CONFIG.SKIP_EMBEDDINGS_SOURCES.
+    """
+    result.next_step = "end"
+
+    if input_payload.source in CONFIG.SKIP_EMBEDDINGS_SOURCES:
+        result.next_step = "exit-ok"
+        result.message = (
+            f"Not currently indexing embeddings for source '{input_payload.source}'"
+        )
+        return result
+
+    # retrieve embeddings count for run
+    td = TIMDEXDataset(location=CONFIG.s3_timdex_dataset_location)
+    embeddings_count = td.metadata.conn.query(f"""
+        select count(*)
+        from data.current_run_embeddings
+        where run_id = '{input_payload.run_id}'
+    """).fetchone()[0]
+
+    # exit early if no embeddings to load
+    if embeddings_count == 0:
+        result.next_step = "exit-ok"
+        result.message = f"No embeddings found for run '{input_payload.run_id}'."
+        return result
+
+    logger.info(
+        f"Preparing TIM command to update {embeddings_count} documents with embeddings."
+    )
+
+    result.embeddings = commands.generate_embeddings_load_command(input_payload)
     return result

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ line-length = 90
 [tool.mypy]
 disallow_untyped_calls = true
 disallow_untyped_defs = true
-exclude = ["tests/"]
+exclude = ["tests/","output/"]
 
 [tool.pytest.ini_options]
 log_level = "INFO"
@@ -27,8 +27,6 @@ ignore = [
     "D107",
     "N812",
     "PTH",
-
-    # project-specific
     "C90",
     "D100",
     "D101",
@@ -36,6 +34,7 @@ ignore = [
     "D103",
     "D104",
     "EM102",
+    "G004",
     "PLR0912",
     "PLR0913",
     "PLR0915",

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -338,3 +338,60 @@ def test_generate_load_commands_unhandled_run_type(run_id):
     }
     with pytest.raises(ValueError, match=r"Input 'run-type' value must be one of:"):
         InputPayload.from_event(event)
+
+
+def test_generate_embeddings_create_command_cpu(run_id):
+    """Record count below threshold uses cpu compute env."""
+    event = {
+        "next-step": "embeddings-create",
+        "run-date": "2022-01-02",
+        "run-type": "daily",
+        "source": "testsource",
+        "run-id": run_id,
+    }
+    input_payload = InputPayload.from_event(event)
+    result = commands.generate_embeddings_create_command(input_payload, record_count=100)
+
+    assert result["create"]["job_compute_env"] == "cpu"
+    assert "create-embeddings-cpu-" in result["create"]["job_name"]
+    assert f"--run-id={run_id}" in result["create"]["command"]
+
+
+def test_generate_embeddings_create_command_gpu_spot(run_id):
+    """Record count at/above threshold uses gpu-spot compute env."""
+    event = {
+        "next-step": "embeddings-create",
+        "run-date": "2022-01-02",
+        "run-type": "daily",
+        "source": "testsource",
+        "run-id": run_id,
+    }
+    input_payload = InputPayload.from_event(event)
+    result = commands.generate_embeddings_create_command(input_payload, record_count=500)
+
+    assert result["create"]["job_compute_env"] == "gpu-spot"
+    assert "create-embeddings-gpu-spot-" in result["create"]["job_name"]
+
+
+def test_generate_embeddings_load_command(run_id):
+    event = {
+        "next-step": "embeddings-load",
+        "run-date": "2022-01-02",
+        "run-type": "daily",
+        "source": "testsource",
+        "run-id": run_id,
+    }
+    input_payload = InputPayload.from_event(event)
+    result = commands.generate_embeddings_load_command(input_payload)
+
+    assert result == {
+        "load": {
+            "bulk-update-embeddings-command": [
+                "--verbose",
+                "bulk-update-embeddings",
+                "--source=testsource",
+                f"--run-id={run_id}",
+                "s3://test-timdex-bucket/dataset",
+            ],
+        }
+    }

--- a/tests/test_format_input.py
+++ b/tests/test_format_input.py
@@ -1,3 +1,5 @@
+# ruff: noqa: E501
+
 from unittest.mock import patch
 
 from lambdas import format_input
@@ -17,6 +19,7 @@ def test_lambda_handler_with_next_step_extract():
     assert output == {
         "run-date": "2022-01-02",
         "run-type": "daily",
+        "run-id": "run-abc-123",
         "source": "testsource",
         "verbose": False,
         "harvester-type": "oai",
@@ -52,6 +55,7 @@ def test_lambda_handler_with_next_step_extract_mitlibwebsite_full():
     assert output == {
         "run-date": "2022-01-02",
         "run-type": "full",
+        "run-id": "run-abc-123",
         "source": "mitlibwebsite",
         "verbose": False,
         "harvester-type": "browsertrix",
@@ -86,6 +90,7 @@ def test_lambda_handler_with_next_step_extract_mitlibwebsite_daily():
     assert output == {
         "run-date": "2022-01-02",
         "run-type": "daily",
+        "run-id": "run-abc-123",
         "source": "mitlibwebsite",
         "verbose": False,
         "harvester-type": "browsertrix",
@@ -123,6 +128,7 @@ def test_lambda_handler_with_next_step_transform_files_present(s3_client, run_ti
     assert format_input.lambda_handler(event, {}) == {
         "run-date": "2022-01-02",
         "run-type": "daily",
+        "run-id": "run-abc-123",
         "source": "testsource",
         "verbose": True,
         "next-step": "load",
@@ -156,6 +162,7 @@ def test_lambda_handler_with_next_step_transform_alma_files_present(run_timestam
     assert format_input.lambda_handler(event, {}) == {
         "run-date": "2022-09-12",
         "run-type": "daily",
+        "run-id": "run-abc-123",
         "source": "alma",
         "verbose": False,
         "next-step": "load",
@@ -222,6 +229,7 @@ def test_lambda_handler_with_next_step_transform_auto_generated_timestamp(s3_cli
     assert result == {
         "run-date": "2022-01-02",
         "run-type": "daily",
+        "run-id": "run-abc-123",
         "source": "testsource",
         "verbose": True,
         "next-step": "load",
@@ -254,6 +262,7 @@ def test_lambda_handler_with_next_step_transform_no_files_present_alma():
         "next-step": "exit-error",
         "run-date": "2022-01-02",
         "run-type": "daily",
+        "run-id": "run-abc-123",
         "source": "alma",
         "verbose": False,
         "message": "There were no transformed files present in the TIMDEX S3 bucket "
@@ -273,6 +282,7 @@ def test_lambda_handler_with_next_step_transform_no_files_present_full():
         "next-step": "exit-error",
         "run-date": "2022-01-02",
         "run-type": "full",
+        "run-id": "run-abc-123",
         "source": "testsource",
         "verbose": False,
         "message": "There were no transformed files present in the TIMDEX S3 bucket "
@@ -292,6 +302,7 @@ def test_lambda_handler_with_next_step_transform_no_files_present_daily():
         "next-step": "exit-ok",
         "run-date": "2022-01-02",
         "run-type": "daily",
+        "run-id": "run-abc-123",
         "source": "testsource",
         "verbose": False,
         "message": "There were no daily new/updated/deleted records to harvest.",
@@ -314,9 +325,10 @@ def test_lambda_handler_with_next_step_load_files_present(s3_client):
         response = format_input.lambda_handler(event, {})
 
     assert response == {
-        "next-step": "end",
+        "next-step": "embeddings-create",
         "run-date": "2022-01-02",
         "run-type": "daily",
+        "run-id": "run-abc-123",
         "source": "testsource",
         "verbose": False,
         "load": {
@@ -353,6 +365,7 @@ def test_lambda_handler_with_next_step_load_no_files_present():
         "next-step": "exit-ok",
         "run-date": "2022-01-02",
         "run-type": "daily",
+        "run-id": "run-abc-123",
         "source": "testsource",
         "verbose": False,
         "message": (
@@ -360,3 +373,43 @@ def test_lambda_handler_with_next_step_load_no_files_present():
             "were found for run_id 'run-abc-123'."
         ),
     }
+
+
+def test_lambda_handler_with_next_step_embeddings_create_skip_source():
+    """Source in SKIP_EMBEDDINGS_SOURCES exits early with message."""
+    event = {
+        "run-date": "2022-01-02",
+        "run-type": "daily",
+        "next-step": "embeddings-create",
+        "source": "alma",
+        "run-id": "run-abc-123",
+    }
+
+    with patch("lambdas.format_input.TIMDEXDataset") as mock_dataset:
+        mock_dataset.return_value.metadata.conn.query.return_value.fetchone.return_value = (
+            0,
+        )
+        response = format_input.lambda_handler(event, {})
+
+    assert response["next-step"] == "exit-ok"
+    assert response["message"] == "Not currently creating embeddings for source 'alma'"
+
+
+def test_lambda_handler_with_next_step_embeddings_load_skip_source():
+    """Source in SKIP_EMBEDDINGS_SOURCES exits early with message."""
+    event = {
+        "run-date": "2022-01-02",
+        "run-type": "daily",
+        "next-step": "embeddings-load",
+        "source": "gisogm",
+        "run-id": "run-abc-123",
+    }
+
+    with patch("lambdas.format_input.TIMDEXDataset") as mock_dataset:
+        mock_dataset.return_value.metadata.conn.query.return_value.fetchone.return_value = (
+            0,
+        )
+        response = format_input.lambda_handler(event, {})
+
+    assert response["next-step"] == "exit-ok"
+    assert response["message"] == "Not currently indexing embeddings for source 'gisogm'"


### PR DESCRIPTION
### Purpose and background context

This PR updates the pipeline lambda to support two new bodies of work in the TIMDEX StepFunction:

1. creating embeddings via an AWS Batch job (`next-step: embeddings-create`)
2. indexing those embeddings into Opensearch via TIM (`next-step: embeddings-load`)

Changes in this repository go hand-in-hand with updates to the StepFunction that are outlined in [this USE-215 comment](https://mitlibraries.atlassian.net/browse/USE-215?focusedCommentId=173265).  

The updated lambda was also used for [this successful StepFunction run in Dev1](https://222053980223-plvs25wd.us-east-1.console.aws.amazon.com/states/home?region=us-east-1#/v2/executions/details/arn:aws:states:us-east-1:222053980223:execution:timdex-ingest-dev-gh-embeddings:96d59997-c810-4616-a6fa-1ad0d6a6b741).

The work of the lambdas to run flow control for embeddings creation + loading is pretty standard and similar to extract, transform, and load.  The following is a very brief explanation of what these two new handlers do:

- `next-step: embeddings-create`
  - analyze the ETL `run-id` and see if there are records to generate embeddings for
  - based on that count, select either `cpu`, `gpu`, or `gpu-spot` as the recommended environment; this gets passed to the StepFunction which runs the correct AWS Batch task
- `next-step: embeddings-load`
  - reads TIMDEX dataset and confirms there are embeddings to index

Both of these new handlers respect a new configuration value `SKIP_EMBEDDINGS_SOURCES = ("alma", "gisogm")`.  If either `alma` or `gisogm` is passed as the source, these handlers will set `next-step: exit-ok` with a message indicating we don't do embeddings for those (see tests  below).

### How can a reviewer manually see the effects of these changes?

1- Set Dev1 TIMDEX credentials in terminal.  These will be used by SAM invocations which query the TIMDEX dataset to analyze ETL runs and embeddings existence.

2- Build updated SAM container for local invocation
```
make sam-build
```

3- Make sure `tests/sam/env.json` exists with the following values:
```json
{  
  "TimdexPipelineLambda": {  
    "TIMDEX_ALMA_EXPORT_BUCKET_ID":"not-needed",  
    "TIMDEX_S3_EXTRACT_BUCKET_ID":"timdex-extract-dev-222053980223"  
  }  
}
```

4- Test handling of `next-step:embeddings-create` for a source we create embeddings for (NOTE: these can be JSON files that are referenced instead of this inlined JSON, but figured this was easier for a PR):
```shell
echo '{"verbose": true, "next-step": "embeddings-create", "run-date": "2026-01-28", "run-type": "full", "run-id": "45f7ea52-ac4c-41e6-b36e-15348cff494a", "source": "libguides"}' | sam local invoke --env-vars tests/sam/env.json -e -
```

Response:
```json
{
  "next-step": "embeddings-load",
  "run-date": "2026-01-28",
  "run-type": "full",
  "run-id": "45f7ea52-ac4c-41e6-b36e-15348cff494a",
  "source": "libguides",
  "verbose": true,
  "embeddings": {
    "create": {
      "job_name": "create-embeddings-cpu-0e05eed3-7485-4589-a24c-099a6aa7791e",
      "job_compute_env": "cpu",
      "command": [
        "--verbose",
        "create-embeddings",
        "--strategy=full_record",
        "--dataset-location=s3://timdex-extract-dev-222053980223/dataset",
        "--run-id=45f7ea52-ac4c-41e6-b36e-15348cff494a"
      ]
    }
  }
}
```
- analyzed the ETL job size and determined that a CPU pipeline should be used via `job_compute_env:cpu`

5- Test handling of `next-step:embeddings-create` for a source we do NOT create embeddings for:
```shell
echo '{"verbose": true, "next-step": "embeddings-create", "run-date": "2026-01-28", "run-type": "full", "run-id": "c2d56168-8fb5-4111-9432-9d59bda22fcf", "source": "alma"}' | sam local invoke --env-vars tests/sam/env.json -e -
```

Response:
```json
{  
  "next-step": "exit-ok",  
  "run-date": "2026-01-28",  
  "run-type": "full",  
  "run-id": "c2d56168-8fb5-4111-9432-9d59bda22fcf",  
  "source": "alma",  
  "verbose": true,  
  "message": "Not currently creating embeddings for source 'alma'"  
}
```
- sets `next-step:exit-ok` because we do not create embeddings for `alma` (or `gisogm`)
- this will indicate to StepFunction to exit early

6- Test handling of `next-step:embeddings-load`, showing the TIM command generated:
```shell
echo '{"verbose": true, "next-step": "embeddings-load", "run-date": "2026-01-28", "run-type": "full", "run-id": "45f7ea52-ac4c-41e6-b36e-15348cff494a", "source": "libguides"}' | sam local invoke --env-vars tests/sam/env.json -e -
```

Response:
```json
{  
  "next-step": "end",  
  "run-date": "2026-01-28",  
  "run-type": "full",  
  "run-id": "45f7ea52-ac4c-41e6-b36e-15348cff494a",  
  "source": "libguides",  
  "verbose": true,  
  "embeddings": {  
    "load": {  
      "bulk-update-embeddings-command": [  
        "--verbose",  
        "bulk-update-embeddings",  
        "--source=libguides",  
        "--run-id=45f7ea52-ac4c-41e6-b36e-15348cff494a",  
        "s3://timdex-extract-dev-222053980223/dataset"  
      ]  
    }  
  }  
}
```
- confirmed that embeddings exist in Dev1 TIMDEX dataset for this job, prepared a TIM command to index them

### Includes new or updated dependencies?
YES

### Changes expectations for external applications?
YES

### What are the relevant tickets?
- https://mitlibraries.atlassian.net/browse/USE-140
