### PR TITLE
IN-1560 - Fix non-standard lambda function name

### DIFF
--- a/.github/workflows/dev-build.yml
+++ b/.github/workflows/dev-build.yml
@@ -20,6 +20,4 @@ jobs:
       AWS_REGION: us-east-1
       GHA_ROLE: timdex-pipeline-lambdas-gha-dev
       ECR: timdex-pipeline-lambdas-dev
-      # Custom function name preserved; this repo deploys the timdex-format lambda.
-      FUNCTION: timdex-format-dev
-      # PREBUILD: # only if there is some pre-build dependency
+      FUNCTION: timdex-format-dev # Lambda function name differs from repository

--- a/.github/workflows/prod-promote.yml
+++ b/.github/workflows/prod-promote.yml
@@ -19,5 +19,4 @@ jobs:
       GHA_ROLE_PROD: timdex-pipeline-lambdas-gha-prod
       ECR_STAGE: timdex-pipeline-lambdas-stage
       ECR_PROD: timdex-pipeline-lambdas-prod
-      # Custom function name preserved; this repo deploys the timdex-format lambda.
-      FUNCTION: timdex-format-prod
+      FUNCTION: timdex-format-prod # Lambda function name differs from repository

--- a/.github/workflows/stage-build.yml
+++ b/.github/workflows/stage-build.yml
@@ -20,6 +20,4 @@ jobs:
       AWS_REGION: us-east-1
       GHA_ROLE: timdex-pipeline-lambdas-gha-stage
       ECR: timdex-pipeline-lambdas-stage
-      # Custom function name preserved; this repo deploys the timdex-format lambda.
-      FUNCTION: timdex-format-stage
-      # PREBUILD: # only if there is some pre-build dependency
+      FUNCTION: timdex-format-stage # Lambda function name differs from repository


### PR DESCRIPTION
### Purpose and background context

This lambda has a non-standard lambda function name `timdex-format-<env>` compared to the repository name `timdex-pipeline-lambdas`.

Note: the worflows don't fire for changes to `.github`, but we'll see this work 🤞 when we promote to production.

### Includes new or updated dependencies?
NO

### Changes expectations for external applications?
NO

### What are the relevant tickets?
- https://mitlibraries.atlassian.net/browse/IN-1560

### Code review
* Code review best practices are documented [here](https://mitlibraries.github.io/guides/collaboration/code_review.html)
and you are encouraged to have a constructive dialogue with your reviewers
about their preferences and expectations.
