### PR TITLE
USE-510 - Temporarily shift to on-demand ec2 vs spot for embeddings

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,18 @@
+# CODEOWNERS file (from GitHub template at
+# https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners)
+# Each line is a file pattern followed by one or more owners.
+
+################################################################################
+# These owners will be the default owners for everything in the repo. This is commented
+# out in favor of using a team as the default (see below). It is left here as a comment
+# to indicate the primary expert for this code.
+# * @ghukill
+
+# Teams can be specified as code owners as well. Teams should be identified in
+# the format @org/team-name. Teams must have explicit write access to the
+# repository.
+* @mitlibraries/dataeng
+
+# We set the senior engineer in the team as the owner of the CODEOWNERS file as
+# a layer of protection for unauthorized changes.
+/.github/CODEOWNERS @ghukill

--- a/.github/pull-request-template.md
+++ b/.github/pull-request-template.md
@@ -15,7 +15,4 @@ YES | NO
 - Include links to Jira Software and/or Jira Service Management tickets here.
 
 ### Code review
-* Code review best practices are documented
-[here](https://mitlibraries.github.io/guides/collaboration/code_review.html)
-and you are encouraged to have a constructive dialogue with your reviewers
-about their preferences and expectations.
+* Code review best practices are documented [here](https://mitlibraries.github.io/guides/collaboration/code_review.html) and you are encouraged to have a constructive dialogue with your reviewers about their preferences and expectations.

--- a/lambdas/commands.py
+++ b/lambdas/commands.py
@@ -203,9 +203,11 @@ def generate_embeddings_create_command(
 
     Determines compute environment based on record count:
     - cpu (ECS Fargate) for < 500 records
-    - gpu-spot (EC2 Spot) for >= 500 records
+    - gpu (EC2 On-Demand) for >= 500 records
+        - NOTE: temporary shift to on-demand only until we have full support for
+        timdex-embeddings batch job restarting if a spot EC2 instance is terminated
     """
-    job_compute_env = "gpu-spot" if record_count >= GPU_RECORD_COUNT_THRESHOLD else "cpu"
+    job_compute_env = "gpu" if record_count >= GPU_RECORD_COUNT_THRESHOLD else "cpu"
 
     return {
         "create": {

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -381,8 +381,12 @@ def test_generate_embeddings_create_command_cpu(run_id):
     assert f"--run-id={run_id}" in result["create"]["command"]
 
 
-def test_generate_embeddings_create_command_gpu_spot(run_id):
-    """Record count at/above threshold uses gpu-spot compute env."""
+def test_generate_embeddings_create_command_gpu(run_id):
+    """Record count at/above threshold uses gpu compute env.
+
+    NOTE: this use of gpu workflow will likely switch back to gpu-spot when
+    timdex-embeddings supports retry for gpu-spot instance terminations.
+    """
     event = {
         "next-step": "embeddings-create",
         "run-date": "2022-01-02",
@@ -393,8 +397,8 @@ def test_generate_embeddings_create_command_gpu_spot(run_id):
     input_payload = InputPayload.from_event(event)
     result = commands.generate_embeddings_create_command(input_payload, record_count=500)
 
-    assert result["create"]["job_compute_env"] == "gpu-spot"
-    assert "create-embeddings-gpu-spot-" in result["create"]["job_name"]
+    assert result["create"]["job_compute_env"] == "gpu"
+    assert "create-embeddings-gpu-" in result["create"]["job_name"]
 
 
 def test_generate_embeddings_load_command(run_id):


### PR DESCRIPTION
### Purpose and background context

**Why these changes are being introduced:**

Until the timdex-embeddings application can support retrying a batch job when a spot EC2 instance is terminated, the decision has been made to use on-demand EC2 instances.

**How this addresses that need:**
* Shifts workflow to 'gpu' vs 'gpu-spot' for embeddings jobs larger than 500

### How can a reviewer manually see the effects of these changes?

See updated test `test_generate_embeddings_create_command_gpu` which confirms that `job_compute_env = gpu` where is used to be `job_compute_env = gpu-spot`.

See also this successful routing to GPU batch job in [this StepFunction run](https://us-east-1.console.aws.amazon.com/states/home?region=us-east-1#/v2/executions/details/arn:aws:states:us-east-1:222053980223:execution:timdex-ingest-dev:ad42400c-5b37-4105-a459-382e686155c9):

<img width="1236" height="603" alt="Screenshot 2026-04-16 at 11 37 39 AM" src="https://github.com/user-attachments/assets/3f3c90d9-fca0-4854-8bc9-a9597bf3efb4" />


### Includes new or updated dependencies?
NO

### Changes expectations for external applications?
YES: We will use more expensive on-demand EC2 instance for larger embedding jobs until we switch back to using spot 

### What are the relevant tickets?
- https://mitlibraries.atlassian.net/browse/USE-510

### Code review
* Code review best practices are documented [here](https://mitlibraries.github.io/guides/collaboration/code_review.html) and you are encouraged to have a constructive dialogue with your reviewers about their preferences and expectations.
